### PR TITLE
Tailwindを導入  close #59

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "tailwindcss-rails", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,18 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.0)
     strscan (3.1.0)
+    tailwindcss-rails (2.7.9)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-aarch64-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-arm-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-arm64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-x86_64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.9-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.3.1)
     timeout (0.4.1)
     turbo-rails (2.0.5)
@@ -294,6 +306,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
+  tailwindcss-rails (~> 2.7)
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
  # 環境構築：-b 0.0.0.0 -p 3000を追加
 web: env RUBY_DEBUG_OPEN=true bin/rails server  -b 0.0.0.0 -p 3000
 js: yarn build --watch
+css: bin/rails tailwindcss:watch

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,11 +15,11 @@
  */
 
 
-body { 
+/* body {
     background-color: #fdea2e;
 
     font-family: "Hiragino Sans","ヒラギノ角ゴシック";
-}
+} */
 
 /*　　　　遊び方　　　　　*/
 #popup-1 {
@@ -549,7 +549,7 @@ button.btn {
 
 /* フラッシュメッセージ */
 #flashMessage{
-    font-size:medium
+    font-size:medium;
     font-weight: small;
     padding-bottom: 10px;
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
 <head>
 <%= favicon_link_tag('favicon.png') %>
 <%# stylesheetのcssファイルと紐付けされる %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 
 
@@ -37,7 +38,7 @@
 
 
 <%# ナビゲーションバーをトグルに変更 %>
-  <body>
+  <body class="bg-red-500">
     <%# ヘッダーを表示、全ページで共通のレイアウトを定義 %>
     <%# クラス名をつけた %>
     <div class="header-container">

--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,16 @@
 #!/usr/bin/env sh
 
-if gem list --no-installed --exact --silent foreman; then
+if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
 
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
 
 exec foreman start -f Procfile.dev "$@"

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,5 +1,7 @@
 set -o errexit
 
+rm ../app/assets/builds/*
+
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,7 +1,8 @@
 set -o errexit
 
-rm ./app/assets/builds/*
-
 bundle install
+
+bundle exec rails assets:clobber
+
 bundle exec rails assets:precompile
 bundle exec rails assets:clean

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,6 +1,6 @@
 set -o errexit
 
-rm ../app/assets/builds/*
+rm ./app/assets/builds/*
 
 bundle install
 bundle exec rails assets:precompile

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -2,7 +2,7 @@ set -o errexit
 
 bundle install
 
+# 卒制：Tailwindを導入追記
 bundle exec rails assets:clobber
 
 bundle exec rails assets:precompile
-bundle exec rails assets:clean

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ]
+}


### PR DESCRIPTION
**1. [Tailwind公式のインストール](https://tailwindcss.com/docs/guides/ruby-on-rails)を実行**  
   - [プロジェクトを作成する](https://tailwindcss.com/docs/guides/ruby-on-rails#:~:text=project%20%2D%2Dcss%20tailwind-,%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B,-%E3%81%BE%E3%81%A0%20Rails%20%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88)は今回はすでにあるのでパス
   - [Tailwind CSSをインストールする](https://tailwindcss.com/docs/guides/ruby-on-rails#:~:text=cd%20my%2Dproject-,Tailwind%20CSS%E3%82%92%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B,-gem%E3%82%92%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB)を実行

**2. `bin/render-build.sh`に`bundle exec rails assets:clobber`を追加**  
   - 変に過去のデータを残さず、消すため  

**3. `app/assets/stylesheets/application.tailwind.css`は不要にもできるが、今回は理解が足りないので`@tailwind`３行を残しておく**  

**4. Tailwindの反映を確認しやすくするため、一旦背景色をTailwindの書き方で赤に変更**  
   - `app/assets/stylesheets/application.css`の`body`(背景黄色)を一旦コメントアウト
   - `app/views/layouts/application.html.erb`に追加：  `<body class="bg-red-500">`