### PR TITLE
既存のCSSをTailwindに書換：フッター、ボディ close #114

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -234,72 +234,9 @@
 
 
 
-/*  */
 
 
-.logo-title {
-    display: flex;
-    justify-content: center;
-    text-align: center;
-}
-/* 　スマホで程よい指示　幅480px以下 */
-/* @media screen and (max-width: 480px) {
-    .logo-title {
-        size: 90%;
-    }
-} */
-
-/*お題とフォーム*/
-.myForm{
-    font-size: large;
-    font: weight 200px;;
-    color: #0090e3;
-    text-align: center;
-}
-/*入力フォーム*/
-#inputData{
-    /*
-    padding: 10px;
-    */
-    font-size: 20px;
-    font-family: "BIZ UDGothic";
-    padding: 10px 10px; /* フォームの中の余白 */
-    border: 3px solid #ffa463; /* 縁の色と太さを変える */
-}
-/*入力フォームを中心に*/
-.inputform{
-    display: flex;
-    justify-content: center;
-}
-/*お題とフォームを二列に*/
-label, input {
-    display: block;
-    margin-bottom: 10px; /* 元は20 */
-    text-align: center;
-}
-
-
-/* 　2つのボタンの並べ方 
-.buttons{
-    display: flex;
-    justify-content:center;
-}*/
-
-
-/* 編集したボタン */
-/*
-*,
-*:before,
-*:after {
-    -webkit-box-sizing: inherit;
-    box-sizing: inherit;
-}
-html {
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-
-}
-*/
+/* めくれるスタートボタン。Tailwindで書けなかった */
 .btn,
 a.btn,
 button.btn {
@@ -323,8 +260,8 @@ button.btn {
     border-radius: 0.5rem;
 
     align-items: center; /* 垂直方向の中央揃え */
-    justify-content: center; /* 水平方向の中央揃え */
-}
+    justify-content: center; /* 水平方向の中央揃え */}
+
 /* 表面の文字色 */
 .btn-3d-circle-front{
     position: absolute;
@@ -334,8 +271,8 @@ button.btn {
     transform: translate(-50%, -50%); /* 要素の中心を真ん中に */
     /* 画面が縮んでも改行しない指示 */
     white-space: nowrap;
-    color: #ff426b; /* 表文字の色 */
-}
+    color: #ff426b; /* 表文字の色 */}
+
 /* 表面の背景 */
 .btn-3d-circle-content {
     display: flex;
@@ -347,7 +284,7 @@ button.btn {
     -webkit-transition: all 0.3s;/* 古いWebKitブラウザ用 */
     transition: all 0.3s; /* 標準ブラウザ用 */
 
-    border: 2px solid #ffffff; /* 縁の色と太さを変える */
+    border: 4px solid #ffffff; /* 縁の色と太さを変える */
     border-radius: 40px;/* 角を丸める */
     background: #ffdde0; /* 表面の背景色 */
 
@@ -355,35 +292,22 @@ button.btn {
 
     transform-style: preserve-3d;
     -webkit-perspective: 150px;
-    perspective: 150px;
-}
-/* 反転の仕方 */
-/*  横に反転する場合
-.btn-3d-circle:hover .btn-3d-circle-content {
-    -webkit-transform: rotateY(0.5turn) rotateX(-0.03turn);
-    transform: rotateY(0.5turn) rotateX(-0.03turn);
-    background: #f2f5f6; /* 裏面の背景色 
-}*/
+    perspective: 150px;}
+
 /*  縦に反転する場合 */
 .btn-3d-circle:hover .btn-3d-circle-content {
     -webkit-transform: rotateX(0.5turn) rotateX(-0.03turn);
     transform: rotateX(0.5turn) rotateX(-0.03turn);
-    background: #f2f5f6; /* 裏面の背景色 */
-    
-}
+    background: #f2f5f6; /* 裏面の背景色 */}
+
 /* 表の文字も反転させないために　0； */
 .btn-3d-circle:hover .btn-3d-circle-front {
-    opacity: 0;
-}
+    opacity: 0;}
 
 /* 裏面を表示 */
 .btn-3d-circle:hover .btn-3d-circle-back {
-    /*
-    top: calc(50% - 2rem);
-    left: calc(50% - 0.75rem);
-    */
-    opacity: 1;
-}
+    opacity: 1;}
+
 /* 裏面の文字の表示の仕方 */
 .btn-3d-circle-back {
     position: absolute;
@@ -391,7 +315,7 @@ button.btn {
     font-size: 62.5%;
     top: 50%; /* まずは真ん中に */
     left: 50%;
-    transform: translate(-50%, -50%); /* 要素の中心を真ん中に */ 
+    transform: translate(-50%, -50%); /* 要素の中心を真ん中に */
     /* 画面が縮んでも改行しない指示 */
     white-space: nowrap;
     color: #52b1ff; /* 表文字の色 */
@@ -399,40 +323,4 @@ button.btn {
     -webkit-transition-duration: 0.5s; /* 古いWebKitブラウザ用 */
     transition-duration: 0.5s;         /* 標準ブラウザ用 */
 
-    opacity: 0;
-}
-
-
-/* フラッシュメッセージ */
-#flashMessage{
-    font-size:medium;
-    font-weight: small;
-    padding-bottom: 10px;
-}
-
-    /* 追加：画面が縮んでも改行しない指示 */
-    /* white-space: nowrap; */
-    /* 追加：画面が縮んでも背景が変わらない */
-    /* width: fit-content;*/
-
-/* お問い合わせ */
-.copyright{
-    margin-left: 20px;
-    top: 0;
-}
-.copyright a{
-    cursor: pointer; /* マウスオーバーでカーソルの形状を変える */
-    font: weight 250px;
-    color: rgb(255, 140, 0);
-    bottom: 0;
-    text-decoration: none;  /* リンク下の線を削除 */
-    font-size: medium;
-}
-.copyright a:hover{
-    cursor: pointer; /* マウスオーバーでカーソルの形状を変える */
-    font-weight:bold; 
-    color: rgb(255, 0, 0);
-    bottom: 0;
-    text-decoration: none;   /* リンク下の線を削除 */
-    font-size: medium;
-}
+    opacity: 0;}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,55 +1,54 @@
 <!DOCTYPE html>
 
 <html lang="ja">
-<head>
-<%= favicon_link_tag('favicon.png') %>
-<%# stylesheetのcssファイルと紐付けされる %>
-    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  <head>
+    <%= favicon_link_tag('favicon.png') %>
+    <%# stylesheetのcssファイルと紐付け %>
+        <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+        <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 
 
-<%# ーーURLをシェアした時にサムネイル画像を表示ーー %>
-  <meta property="og:url" content="https://aruaru-game.onrender.com/">
-  <meta property="og:type" content="website">
-  <meta property="og:title" content="あるある神経衰弱：界隈探求ゲーム">
-  <meta property="og:description" content="あらゆる界隈のあるあるを作って遊ぼう！人は誰しも何かのオタクでしょう？？">
-  <meta property="og:site_name" content="TOP">
-  <meta property="og:image" content="<%= image_url('URL-SHARE_mini.png') %>" />
+    <%# 静的OGP %>
+      <meta property="og:url" content="https://aruaru-game.onrender.com/">
+      <meta property="og:type" content="website">
+      <meta property="og:title" content="あるある神経衰弱：界隈探求ゲーム">
+      <meta property="og:description" content="あらゆる界隈のあるあるを作って遊ぼう！人は誰しも何かのオタクでしょう？？">
+      <meta property="og:site_name" content="TOP">
+      <meta property="og:image" content="<%= image_url('URL-SHARE_mini.png') %>" />
 
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:site" content="@pakira_rrr" />
-  <meta name="twitter:description" content="あらゆる界隈のあるあるを作って遊ぼう！人は誰しも何かのオタクでしょう？？" />
-  <meta name="twitter:image" content="<%= asset_url('URL-SHARE_mini.png') %>" />
-
-
-<%# ナビゲーションバーをメニューに変更 %>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
-
-<%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>あるある神経衰弱</title>
-  <style>
-    .menu-content {
-      display: none;}
-  </style>
-
-</head>
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@pakira_rrr" />
+      <meta name="twitter:description" content="あらゆる界隈のあるあるを作って遊ぼう！人は誰しも何かのオタクでしょう？？" />
+      <meta name="twitter:image" content="<%= asset_url('URL-SHARE_mini.png') %>" />
 
 
-<%# ナビゲーションバーをメニューに変更 %>
-  <body class="bg-custom-yellow">
-    <%# ヘッダーを表示、全ページで共通のレイアウトを定義 %>
-    <%# クラス名をつけた %>
+
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>あるある神経衰弱</title>
+      <style>
+        .menu-content {
+          display: none;}
+      </style>
+
+  </head>
+
+
+  <header>
     <div class="header-container">
     <%= render 'shared/header' %>
     </div>
-    <%= yield %>
+  </header>
 
-    <%# フッターを表示、全ページで共通のレイアウトを定義 %>
-    <div class="footer-container">
-    <%= render 'shared/footer' %>
+  <body class="bg-custom-yellow">
+    <%= yield %>
   </body>
 
-</div>
+  <footer>
+    <div class="footer-container">
+      <%= render 'shared/footer' %>
+    </div>
+  </footer>
+
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,5 @@
-<!-- フッターを用意 -->
 <footer id='footer' class='footer-bottom'>
-<div class='copyright'>
-
-<a href="https://x.com/pakira_rrr" >
-    <class= 'rounded-circle mr15', width: '15', height: '15'>
-    お問い合わせ
-</a>
-
-</div>
+    <div class='ml-5'>
+        <a href="https://x.com/pakira_rrr" class='text-orange-500 hover:text-red-500 hover:font-bold no-underline'>お問い合わせ</a>
+    </div>
 </footer>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -2,84 +2,33 @@
 
 <!DOCTYPE html>
 <html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>リスト一覧？</title>
-</head>
-<body>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>トップページ</title>
+    </head>
 
-<%# ロゴ %>
-<div class="logo-title">
-<%= image_tag 'logo-clear.png', class: 'rounded-circle mr15', width: '400', height: '400' %>
-</div>
+    <body class="text-center">
 
-<%# 入力フォームとスタートボタン %>
-    <form id="myForm" class="myForm">
-        <label for="inputData">どの界隈のあるあるで遊ぶ？🤔</label>
-        <div class="inputform">
-        <input type="text" id="inputData" name="inputData">
-        </div>
+    <div class="flex justify-center">
+        <%= image_tag 'logo-clear.png', class: 'rounded-full w-96 h-96' %>
+    </div>
 
-        <%# ★★★★★★ フラッシュメッセージの表示 %>
-        <%#
-            <div id="flashMessage" class="flash-message"></div>
-        %>
-            <%# ★★★★★★ 未入力の場合の処理：フラッシュメッセージの表示 %>
-            <div id="flashMessage" style="display:none; color:red;"></div>
-
-            <%# ★★★★★★ 入力済み場合の処理：フラッシュメッセージ用の要素を取得 %>
-            <div id="flashMessage" style="display:none; color:green;"></div>
-
-
-        <%# ーーーーーースタートボタンーーーーーーーー %>
-        <a href="#" class="btn btn-3d-circle" id="button1">
-            <span class="btn-3d-circle-content">
-                <span class="btn-3d-circle-front">神経衰弱スタート</span>
-            </span>
-                <span class="btn-3d-circle-back">めくって知ろう！</span>
-        </a>
-    </form>
-
-    <script>
-        function handleSubmit() {
-            // フォームデータを取得
-            const inputData = document.getElementById('inputData').value;
-
-            //  ★★★★★★ フラッシュメッセージ用の要素を取得
-            const flashMessage = document.getElementById('flashMessage');
-
-            //  ★★★★★★ 未入力の場合の処理
-            if (!inputData) {
-                flashMessage.textContent = 'どの界隈のあるあるが知りたいか教えてね👀';
-                flashMessage.style.display = 'block';
-                return;
-            } else {
-                flashMessage.style.display = 'none';
-            }
-
-            // ★★★★★★ 入力された場合のフラッシュメッセージ
-            flashMessage.textContent = 'まだ遊べないんだぁ、待っててね😀';
-            flashMessage.style.display = 'block';
-
-            // AIにデータを送信する一旦Geminiを登録
-            fetch('https://gemini.google.com/', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ data: inputData })
-            })
-            .then(response => response.json())
-            .then(data => {
-                console.log('Success:', data);
-                // データ送信が成功したらゲームスタート画面に遷移
-                window.location.href = '/game-start';
-            })
-            .catch((error) => {
-                console.error('Error:', error);
-            });
-        }
-    </script>
-</body>
+        <form id="myForm" class="font-light text-lg text-[#0090e3] ">
+            <label for="inputData" class="block mb-2 text-center">どの界隈のあるあるで遊ぶ？🤔</label>
+                <div class="flex justify-center mb-4">
+                    <input type="text" placeholder="例）ONEPIECE：イーストブルー編"
+                        id="inputData" name="inputData"
+                        class="w-[380px] p-2 border-4 border-[#ffa463] rounded text-left font-family-['BIZ UDGothic'] placeholder-[#cecece]" />
+                </div>
+            <div class="flex justify-center">
+                <a href="#" class="btn btn-3d-circle " id="button">
+                    <span class="btn-3d-circle-content">
+                        <span class="btn-3d-circle-front">神経衰弱スタート</span>
+                    </span>
+                        <span class="btn-3d-circle-back">めくって知ろう！</span>
+                </a>
+            </div>
+        </form>
+    </body>
 </html>


### PR DESCRIPTION
**書き換えた場所**
- フッダー
- ボディ

**残した箇所**
- `app/assets/stylesheets/application.css`のめくれるスタートボタン
  - どうしてもTailwindで書き替えられなかった
  - 神経衰弱を連想するボタンであって欲しいので、CSSとして残す。

**削除したもの**
- 既存のCSS
- `app/views/tops/index.html.erb`のフラッシュメッセージ処理