### PR TITLE
render-buildにコメント追加・遊び方モーダル再調整 close #132

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,7 +23,6 @@
     right: 20px;
     width: auto;}
 
-
 .menus-button :hover{content: url('header/menu/menus-hover.svg');}
 
 .menus-area{

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
 
 
   <header>
-    <div class="header-container flex justify-between items-center relative top-2 ">
+    <div class="header-container flex justify-between items-center relative top-6">
     <%= render 'shared/header' %>
     </div>
   </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,50 +1,47 @@
-<button class="font-bold text-[#F50968] hover:text-[#5099ff] left-5 top-2" onclick="howto.showModal()">遊び方</button>
+<button class="font-bold text-2xl text-[#F50968] hover:text-[#5099ff] left-6" onclick="howto.showModal()">遊び方</button>
 <dialog id="howto" class="modal">
-    <div class="modal-box fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg max-w-[400px] p-2 z-50">
-        <h3 class="text-pink-500 font-bold text-2xl text-center text-[#ff0090]">🥳　遊び方　🥳</h3>
-        <br>
-        <div class="howto-text text-[#ff5900] text-left whitespace-nowrap leading-400 px-8 py-8 left-2">
+    <div class="modal-box fixed  transform  bg-white rounded-lg max-w-[600px] p-2 z-50">
+        <p class="py-2">
+        <h3 class="text-pink-500 font-bold p-2 text-xl text-center text-[#ff0090]">🥳　遊び方　🥳</h3>
+        <div class="howto-text text-[#ff5900] text-left whitespace-nowrap leading-400 px-6 py-8 left-2">
             <div class="font-bold text-center">あらゆる界隈をすこーし探求できるゲーム</div>
             <br>
             ①あるあるを知りたい界隈を入力！<br>
             ＡＩがあるあるを生成してくれるよ
             <div class="flex">
-            <%= image_tag 'header/AI-search.png', width: '70', height: '70' %>
+            <%= image_tag 'header/AI-search.png', width: '60', height: '60' %>
             <%= image_tag 'header/AI-lines.jpeg', width: '320', height: '60' %>
             </div>
             <br>
             <div class="flex">②<%= image_tag 'header/start-button.png', class: 'rounded-circle mr-2', width: '130', height: '2' %>で</div>
             札をめくって、あるあるのペアを作ろう！
             <div class="flex space-x-3">
-                <%= image_tag 'header/card.png',  width: '70', height: '70' %>
-                <%= image_tag 'header/card-2.jpeg',  width: '70', height: '70' %>
-                <%= image_tag 'header/card.png',  width: '70', height: '70' %>
-                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-500 rounded-lg', width: '70', height: '70' %>
-                <%= image_tag 'header/pea.jpeg',  width: '150', height: '70' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card-2.jpeg',  width: '60', height: '60' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
+                <%= image_tag 'header/pea.jpeg',  width: '150', height: '60' %>
                 <br>
             </div>
             <div class="flex space-x-3">
-                <%= image_tag 'header/card.png',  width: '70', height: '70' %>
-                <%= image_tag 'header/card.png',  width: '70', height: '70' %>
-                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-500 rounded-lg', width: '70', height: '70' %>
-                <%= image_tag 'header/card.png',  width: '70', height: '70' %>
-                <%= image_tag 'header/pea-lines.png',  width: '200', height: '70' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/pea-lines.png',  width: '200', height: '60' %>
             </div>
             <br>
             <div class="flex space-x-3">
                 ③左上の <%= image_tag 'header/menu/menus.svg', width: '30', height: '30' %> から
                 </div>
-                誰かのあるあるで遊んだり、自作してシェアしよう💃
+                誰かのあるあるで遊んだり、自作してシェアしよう！
                 </div>
-                <br>
-            <form method="dialog" class="modal-backdrop" onclick="howto.close()">
-                <button>閉じる</button>
-            </form>
             </div>
+        <form method="dialog" class="modal-backdrop mix-blend-multiply bg-[#FFAB508D]" onclick="howto.close()"></form>
         </div>
+        </p>
     </div>
 </dialog>
-
 
 
 <nav>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,15 +1,17 @@
+# エラーチェックを有効にして、コマンドが失敗したらスクリプトを終了
 set -o errexit
-
+# Gemの依存関係を解決し、必要なライブラリをインストール
 bundle install
 
-
-# 卒制：Tailwindを導入追記
+# 既存のアセットを削除し、ディレクトリをクリーンにする
 bundle exec rails assets:clobber
 
-# 10.19.追記（10.20.5行目から移動）
+# JavaScript依存ライブラリをインストール
 yarn install
+# JavaScriptやCSSをビルド
 yarn build
+# CSSを圧縮して最適化
 yarn build:css_minify
 
+# アセットをプリコンパイルして本番環境用に準備
 bundle exec rails assets:precompile
-


### PR DESCRIPTION
### 経緯
[DaisyUI導入・遊び方モーダルを書き換え](https://github.com/pakira-56A/aruaru-game/pull/127)を行ったが、**本番とローカルでCSSが全く違った！**

[Postcssをインストール](https://github.com/pakira-56A/aruaru-game/pull/128)したのち
Tailwindがインストールされておらず、Gemだったことが発覚😱
- [gemのTailwindを、yarnで入れ直した](https://github.com/pakira-56A/aruaru-game/pull/129)
- [Tailwindの読み込み問題を解決](https://github.com/pakira-56A/aruaru-game/pull/130)

やっと本番とローカルのCSSが一致したので、モーダルを再調整
_____
# 実装内容
- [DaisyUI公式のモーダル](https://daisyui.com/components/modal/#:~:text=Dialog%20modal%2C%20closes%20when%20clicked%20outside)と同じように、説明テキストの前に
`p`タグのクラスを定義すると、モーダル外のクリックで閉じた！
- `class="modal-backdrop"`に`mix-blend-multiply bg-[#FFAB508D]`を追加でオーバーレイ色を指定できた