### PR TITLE
既存のCSSをTailwindに書換ヘッダーのメニューリスト close #126

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,79 +15,8 @@
  */
 
 /*メニュー*/
-.menus{
-    /* header/menu/menu-1メニューとheader/menu/menu-3メニューを一括りにしたクラス */
-    position:relative;
-    justify-content: flex-end; /* 追加：親要素に追加すると子が右寄せになる */
-    cursor: pointer;
-    right: 20px;
-    width: auto;}
-
 .menus-button :hover{content: url('header/menu/menus-hover.svg');}
-
-.menus-area{
-    position: fixed;
-    max-width: 330px;
-    top: 70px;
-    right: 25px;}
-
-.menu-list1{
-    line-height: 25px;
-    list-style: none; /*先頭の・を非表示*/
-    background-color: rgb(254, 255, 240);
-    padding: 15px; /* 追加 */
-    border-radius: 10px;/* 角を丸める */
-
-    /* 追加：画面が縮んでも改行しない指示 */
-    white-space: nowrap;
-    /* 追加：画面が縮んでも背景が変わらない */
-    width: fit-content;}
-
-.menu-list1 li{
-    padding: 10px;}
-
-.menu-list1 li a{
-    /* menu-listの中のliタグの中のaタグを編集 */
-    font-weight: bold;
-    display: flex;
-    justify-content: left;
-    align-items: center;
-    text-decoration: none;  /* リンク下の線を削除 */
-    gap: 5px; /*アイコンとの距離が離れる*/}
-
-.menu-list1 li a{ color: #019c8f;}
-.menu-list1 li a:hover{ color: #00e297;}
-.menu-list1 li a:hover #image-menu1 {content: url('header/menu/menu-1-hover.svg');}
-
-.menu-list2 li a{ color: #0088D0;}
-.menu-list2 li a:hover{ color: #00c5ff;}
-.menu-list2 li a:hover #image-menu2 {content: url('header/menu/menu-2-hover.svg');}
-
-.menu-list3 li a{ color: #DF5656;}
-.menu-list3 li a:hover{ color: #fe9898;}
-.menu-list3 li a:hover #image-menu3 { content: url('header/menu/menu-3-hover.svg');}
-
-.menu-list4 li a{ color: #818181;}
-.menu-list4 li a:hover{ color: #b7b7b7;}
-.menu-list4 li a:hover #image-menu4 { content: url('header/menu/menu-4-hover.svg');}
-
-/* 　幅480以上の画面で見た場合 */
-@media screen and (min-width: 480px) {
-    .menus-area{
-        top: 70px;
-        right: 20px;  /*リストの位置 */
-    }}
-
-/* 　幅480px以下の画面で見た場合 */
-@media screen and (max-width: 480px) {
-    .menus-area{
-        top: 70px;
-        right: 20px;  /*リストの位置 */
-    }}
-
-/* 　幅570px以上の画面で見た場合 */
-@media screen and (max-width: 570px) {
-    .menus-area{
-        top: 70px;
-        right: 20px;  /*リストの位置 */
-    }}
+.menu-list1 a:hover #image-menu1 {content: url('header/menu/menu-1-hover.svg');}
+.menu-list2 a:hover #image-menu2 {content: url('header/menu/menu-2-hover.svg');}
+.menu-list3 a:hover #image-menu3 { content: url('header/menu/menu-3-hover.svg');}
+.menu-list4 a:hover #image-menu4 { content: url('header/menu/menu-4-hover.svg');}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,11 +33,8 @@
 
   </head>
 
-
   <header>
-    <div class="header-container flex justify-between items-center relative top-6">
     <%= render 'shared/header' %>
-    </div>
   </header>
 
   <body class="bg-custom-yellow">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,74 +1,80 @@
-<button class="font-bold text-2xl text-[#F50968] hover:text-[#5099ff] left-6 drop-shadow-lg" onclick="howto.showModal()">遊び方</button>
-<dialog id="howto" class="modal">
-    <div class="modal-box fixed  transform  bg-white rounded-lg max-w-[600px] p-2 z-50 drop-shadow-lg">
-        <p class="py-2">
-        <h3 class="text-pink-500 font-bold p-2 text-xl text-center text-[#ff0090]">🥳　遊び方　🥳</h3>
-        <div class="howto-text text-[#ff5900] text-left whitespace-nowrap leading-400 px-6 py-8 left-2">
-            <div class="font-bold text-center">あらゆる界隈をすこーし探求できるゲーム</div>
-            <br>
-            ①あるあるを知りたい界隈を入力！<br>
-            ＡＩがあるあるを生成してくれるよ
-            <div class="flex">
-            <%= image_tag 'header/AI-search.png', width: '60', height: '60' %>
-            <%= image_tag 'header/AI-lines.jpeg', width: '320', height: '60' %>
-            </div>
-            <br>
-            <div class="flex">②<%= image_tag 'header/start-button.png', class: 'rounded-circle mr-2', width: '130', height: '2' %>で</div>
-            札をめくって、あるあるのペアを作ろう！
-            <div class="flex space-x-3">
-                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                <%= image_tag 'header/card-2.jpeg',  width: '60', height: '60' %>
-                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
-                <%= image_tag 'header/pea.jpeg',  width: '150', height: '60' %>
-                <br>
-            </div>
-            <div class="flex space-x-3">
-                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
-                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                <%= image_tag 'header/pea-lines.png',  width: '200', height: '60' %>
-            </div>
-            <br>
-            <div class="flex space-x-3">
-                ③左上の <%= image_tag 'header/menu/menus.svg', width: '30', height: '30' %> から
+<div class="flex justify-between items-center">
+    <div class="grid grid-cols-3 flex mt-6">
+        <div class="flex">
+        <button class="font-bold text-2xl whitespace-nowrap text-[#F50968] hover:text-[#5099ff] drop-shadow-lg ml-6"
+        onclick="howto.showModal()">遊び方</button>
+        <dialog id="howto" class="modal">
+            <div class="modal-box fixed  transform  bg-white rounded-lg max-w-[600px] p-2 z-50 drop-shadow-lg">
+                <p class="py-2">
+                <h3 class="text-pink-500 font-bold p-2 text-xl text-center text-[#ff0090]">🥳　遊び方　🥳</h3>
+                <div class="howto-text text-[#ff5900] text-left whitespace-nowrap leading-400 px-6 py-8 left-2">
+                    <div class="font-bold text-center">あらゆる界隈をすこーし探求できるゲーム</div>
+                    <br>
+                    ①あるあるを知りたい界隈を入力！<br>
+                    ＡＩがあるあるを生成してくれるよ
+                    <div class="flex">
+                    <%= image_tag 'header/AI-search.png', width: '60', height: '60' %>
+                    <%= image_tag 'header/AI-lines.jpeg', width: '320', height: '60' %>
+                    </div>
+                    <br>
+                    <div class="flex">②<%= image_tag 'header/start-button.png', class: 'rounded-circle mr-2', width: '130', height: '2' %>で</div>
+                    札をめくって、あるあるのペアを作ろう！
+                    <div class="flex space-x-3">
+                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                        <%= image_tag 'header/card-2.jpeg',  width: '60', height: '60' %>
+                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                        <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
+                        <%= image_tag 'header/pea.jpeg',  width: '150', height: '60' %>
+                        <br>
+                    </div>
+                    <div class="flex space-x-3">
+                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                        <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
+                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                        <%= image_tag 'header/pea-lines.png',  width: '200', height: '60' %>
+                    </div>
+                    <br>
+                    <div class="flex space-x-3">
+                        ③左上の <%= image_tag 'header/menu/menus.svg', width: '30', height: '30' %> から
+                        </div>
+                        誰かのあるあるで遊んだり、自作してシェアしよう！
+                        </div>
+                    </div>
+                <form method="dialog" class="modal-backdrop mix-blend-multiply bg-[#FFAB508D]" onclick="howto.close()"></form>
                 </div>
-                誰かのあるあるで遊んだり、自作してシェアしよう！
+                </p>
+            </div>
+        </dialog>
+
+        <nav class="flex justify-end">
+            <div class="menus cursor-pointer drop-shadow-lg mr-6 mt-6">
+                <a id="menus-button" class="menus-button">
+                <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id:'image-menus-button'%>
+                </a>
+                <div id="menus-area" class="fixed max-w-[400px] top-[55px] right-[4px] bg-white rounded-[10px] drop-shadow-lg">
+                    <div class="flex flex-col list-none whitespace-nowrap py-4 px-6">
+                        <div class="menu-list1 text-[#019c8f] hover:text-[#00e297]">
+                            <a href="/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4 pr-8">
+                                <%= image_tag 'header/menu/menu-1.svg', width: '30', height: '30',id:'image-menu1' %>
+                                誰かが作ったあるあるで遊ぶ</a></div>
+                        <div class="menu-list2 text-[#0088D0] hover:text-[#00c5ff]" >
+                            <a href="/user/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
+                                <%= image_tag 'header/menu/menu-2.svg', width: '25', height: '25',id:'image-menu2' %>
+                                自分であるあるを作って投稿</a></div>
+                        <div class="menu-list3 text-[#DF5656] hover:text-[#fe9898]" >
+                            <a href="/bookmarks" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
+                                <%= image_tag 'header/menu/menu-3.svg', width: '25', height: '25',id:'image-menu3' %>
+                                お気に入りの界隈をみる</a></div>
+                        <div class="menu-list4 text-[#818181] hover:text-[#b7b7b7]" >
+                            <a href="/settings" class="font-bold flex justify-start items-center no-underline gap-2">
+                                <%= image_tag 'header/menu/menu-4.svg', width: '25', height: '25',id:'image-menu4' %>
+                                設定</a></div>
+                    </div>
                 </div>
             </div>
-        <form method="dialog" class="modal-backdrop mix-blend-multiply bg-[#FFAB508D]" onclick="howto.close()"></form>
-        </div>
-        </p>
-    </div>
-</dialog>
+        </nav>
 
-
-<nav>
-    <div class="menus">
-        <span id="menus-button" class="menus-button">
-        <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id:'image-menus-button'%>
-        </span>
-        <div id="menus-area" class="menus-area">
-            <div class="menu-list1" >
-                <li>
-                <a href="/index">
-                <%= image_tag 'header/menu/menu-1.svg', width: '30', height: '30',id:'image-menu1' %>
-                誰かが作ったあるあるで遊ぶ</a>
-                </li>
-            <div class="menu-list2" >
-                <li><a href="/user/index">
-                <%= image_tag 'header/menu/menu-2.svg', width: '25', height: '25',id:'image-menu2' %>
-                自分であるあるを作って投稿</a></li>
-            <div class="menu-list3" >
-                <li><a href="/bookmarks">
-                <%= image_tag 'header/menu/menu-3.svg', width: '25', height: '25',id:'image-menu3' %>
-                お気に入りの界隈をみる</a></li>
-            <div class="menu-list4" >
-                <li><a href="/settings">
-                <%= image_tag 'header/menu/menu-4.svg', width: '25', height: '25',id:'image-menu4' %>
-                設定</a></li>
-            </div>
         </div>
     </div>
-</nav>
+</div>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -11,21 +11,19 @@
     <body class="text-center">
 
     <div class="flex justify-center">
-        <%= image_tag 'logo-clear.png', class: 'rounded-full w-96 h-96' %>
+        <%= image_tag 'logo-clear.png', class: 'w-96 h-96' %>
     </div>
 
         <form id="myForm" class="font-light text-lg text-[#0090e3] ">
             <label for="inputData" class="block mb-2 text-center">どの界隈のあるあるで遊ぶ？🤔</label>
                 <div class="flex justify-center mb-4">
-                    <input type="text" placeholder="例）ONEPIECE：イーストブルー編"
-                        id="inputData" name="inputData"
+                    <input type="text" placeholder="例）ONEPIECE：イーストブルー編" id="inputData" name="inputData"
                         class="w-[360px] p-2 border-4 border-[#ffa463] rounded text-left font-family-['BIZ UDGothic'] placeholder-[#cecece]" />
                 </div>
 
             <div class="flex justify-center relative inline-block ">
                 <a href="#" class="start-btn
-                opacity-1
-                transition-all duration-300 flex items-center justify-center rounded-md">
+                opacity-1 transition-all duration-300 flex items-center justify-center rounded-md">
 
                     <div class="start-btn-content shadow-md
                     flex w-[260px] h-[70px] border-4 border-white rounded-[40px] bg-[#ffdde0]
@@ -43,15 +41,13 @@
                         background: #f2f5f6; }
                     </style>
 
-                        <div class="start-btn-front
-                        duration-500
+                        <div class="start-btn-front duration-500
                         text-[#ff426b] font-bold text-lg whitespace-nowrap absolute
                         top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2
                         transition-opacity duration-500 opacity-100 ">
                             神経衰弱スタート
                         </div>
-                        <div class="start-btn-back
-                        duration-300 rotate-180 -scale-x-100
+                        <div class="start-btn-back duration-300 rotate-180 -scale-x-100
                         text-[#52b1ff] font-bold text-lg whitespace-nowrap absolute
                         top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2
                         transition-opacity opacity-0 hover:opacity-100">


### PR DESCRIPTION
**書き換えた場所**
- ヘッダーのメニュー・メニューリスト

**削除したもの**
- 既存のCSS（一部）

**書き換えられず、残しているもの**
- ホバーした際、アイコン画像が変わる記述
- `app/views/shared/_header.html.erb`内に`<style>`タグで設置しようとしたができず。  
  `app/assets/stylesheets/application.css`に残した
[![Image from Gyazo](https://i.gyazo.com/200f56e9d14f3447155641d2fc4bd874.png)](https://gyazo.com/200f56e9d14f3447155641d2fc4bd874)左がホバーした際の様子