### PR TITLE
システムテスト用のファイルを生成しないよう設定を追記、topsの不要なファイルや記述を削除 close #158

### DIFF
--- a/app/helpers/tops_helper.rb
+++ b/app/helpers/tops_helper.rb
@@ -1,2 +1,0 @@
-module TopsHelper
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,12 +15,13 @@ module Myapp
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
-        # Rails generatorの設定を加える記述
-        config.generators do |g|
-          g.skip_routes true
-          g.helper false
-          g.test_framework nil
-        end
+
+    config.generators.system_tests = nil
+    config.generators do |g|
+      g.skip_routes true
+      g.helper false
+      g.test_framework nil
+    end
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,4 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   root "tops#index"
-  get "tops/index"
 end


### PR DESCRIPTION
Rails generator の設定に
**システムテスト用のファイルを生成しないよう設定を追記**
`config/application.rb`
```rb
require_relative "boot"
...
    config.generators.system_tests = nil     #今回追記した記述
    config.generators do |g|
      g.skip_routes true
      g.helper false
      g.test_framework nil
    end
...
```
　
**不要な「ルーティングの追記」「ヘルパーファイル」「テストファイル」を削除**
（#151 #153  は不要な作業だと気づき修正）
- `app/helpers/tops_helper.rb`
- `routes.rb`の`get "tops/index"`