### PR TITLE
Google認証#5：本番環境で公開。「トップへ戻る」ボタン設置 close #170

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -45,7 +45,7 @@
                 </div>
                 </p>
             </div>
-        </dialog>
+    </dialog>
 
 
     <div class="google_login_button mt-6 mr-6">
@@ -53,7 +53,7 @@
 
         <div id="g_id_onload"
             data-client_id="<%= ENV['GOOGLE_CLIENT_ID'] %>"
-            data-login_uri="http://localhost:3000/google_login_api/callback"
+            data-login_uri="https://aruaru-game.onrender.com/google_login_api/callback"
             data-auto_prompt="false">
         </div>
         <div class="g_id_signin bg-custom-yellow"
@@ -68,7 +68,7 @@
     </div>
 
 
-        <nav class="flex justify-end">
+    <nav class="flex justify-end">
             <div class="menus cursor-pointer drop-shadow-lg mr-6 mt-6">
                 <a id="menus-button" class="menus-button">
                 <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id:'image-menus-button'%>

--- a/app/views/tops/policy.html.erb
+++ b/app/views/tops/policy.html.erb
@@ -48,4 +48,7 @@
         <p class="mb-4">お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、<a href="https://docs.google.com/forms/d/18ZqQchVUQhLMo8hjqlj0_ig74KAnTrmrV46cCb-L0MQ/prefill" class="text-blue-500 hover:underline">お問い合わせフォーム</a>よりご連絡ください。</p>
         <p class="mb-4 text-right">2024年10月29日 制定</p>
     </section>
+    <%= link_to 'トップへ戻る', '/toppage',
+    class: 'nav-link text-orange-500 hover:text-red-500 hover:font-bold no-underline
+        border-solid border border-stone-200 rounded-lg bg-white'%>
 </section>

--- a/app/views/tops/term.html.erb
+++ b/app/views/tops/term.html.erb
@@ -257,4 +257,7 @@
     <section>
         <h2 class="mb-4 text-right">2024年10月29日 制定</h2>
     </section>
+    <%= link_to 'トップへ戻る', '/toppage',
+    class: 'nav-link text-orange-500 hover:text-red-500 hover:font-bold no-underline
+        border-solid border border-stone-200 rounded-lg bg-white'%>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
 
   get "/policy", to: "tops#policy"
   get "/term", to: "tops#term"
+  get "/toppage", to: "tops#toppage"
 end


### PR DESCRIPTION
**該当issue**： #170 

本番環境にデプロイするときにやること：[参考資料](https://zenn.dev/yoiyoicho/articles/c44a80e4bb4515#%E6%9C%AC%E7%95%AA%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AF%EF%BC%9F)
- Google API Consoleで、承認済みの JavaScript 生成元、承認済みのリダイレクト URIを本番環境のものに差し替える
- Google API Consoleで、アプリの公開ステータスを本番環境に切り替える
- `app/views/shared/_header.html.erb`のGoogleログインボタン
  - HTMLの`data-login_uri`を本番環境のものに差し替える

### 24.10.29.14:00ごろ、Google APIに確認ステータスを送信。返事待ちの状態です。
[![Image from Gyazo](https://i.gyazo.com/f20e5974445606f09fd90be24610b25f.png)](https://gyazo.com/f20e5974445606f09fd90be24610b25f)
___
`プラポリ` `利用規約`画面からトップページに戻るボタンを設置
