### PR TITLE
Google認証#6：認証したデータでユーザー登録、ログイン後の遷移先をローカルと本番で変更。Renderでデータベース作成・連携 。 close #175

### DIFF
--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -8,9 +8,17 @@ class GoogleLoginApiController < ApplicationController
 
   def callback
     payload = Google::Auth::IDTokens.verify_oidc(params[:credential], aud: ENV['GOOGLE_CLIENT_ID'])
-    user = User.find_or_create_by(email: payload['email'])
-    session[:user_id] = user.id
-    redirect_to after_login_path, notice: 'ログインできたよ'
+    begin
+      generated_password = Devise.friendly_token
+      user = User.find_or_create_by!(email: payload['email']) do |u|
+                u.password = generated_password
+                u.name = payload['name']
+              end
+      session[:user_id] = user.id
+      redirect_to after_login_path, notice: 'ログインできたよ'
+    rescue => e
+        pp e
+    end
   end
 
   private

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -53,7 +53,8 @@
 
         <div id="g_id_onload"
             data-client_id="<%= ENV['GOOGLE_CLIENT_ID'] %>"
-            data-login_uri="https://aruaru-game.onrender.com/google_login_api/callback"
+            data-login_uri=
+            "<%= Rails.env.development? ? 'http://localhost:3000/google_login_api/callback' : 'https://aruaru-game.onrender.com/google_login_api/callback' %>"
             data-auto_prompt="false">
         </div>
         <div class="g_id_signin bg-custom-yellow"

--- a/app/views/tops/my_index.html.erb
+++ b/app/views/tops/my_index.html.erb
@@ -1,6 +1,7 @@
 
 <% if notice.present? %>
-<p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+<p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice">
+<%= notice %></p>
 <% end %>
 
 <h1>Tops#my_index</h1>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -6,6 +6,9 @@ bundle install
 # 既存のアセットを削除し、ディレクトリをクリーンにする
 bundle exec rails assets:clobber
 
+# Renderのデータベースと連携用に追記
+bundle exec rails db:migrate
+
 # JavaScript依存ライブラリをインストール
 yarn install
 # JavaScriptやCSSをビルド


### PR DESCRIPTION
- プルリク： #171  
  issue： #170 で書いた  
  「**Google APIに確認ステータスを送信。返事待ちの状態」の件**
  Google APIの設定を変更し不要になったので、返事を待たずに本番環境で認証機能が使える様になりました！
  原因：Google APIの設定でロゴを登録していたため

- **Render(デプロイツール)に環境変数を渡した**  
  クライアントIDとクライアントシークレットは、`.env`には書いたがGitHub上に上げてないので
  Renderは`.env`の中身を知らない！渡してあげないと本番環境で環境変数がつかえない！！

- **Renderでデータベースを作成・連携**
  - `bin/render-build.sh`に`bundle exec rails db:migrate`追記

- **ローカルと本番で、リダイレクト先を分けたい！**  
  ローカル環境で認証成功したらhttp://localhost:3000/google_login_api/callback
  本番環境で認証成功したらhttps://aruaru-game.onrender.com/google_login_api/callback
  にリダイレクトするようにしたい！
    - google APIの設定に追記
    - `app/views/shared/_header.html.erb`の`data-login_uri`を三項演算子に変更
  
- **ローカルではDBが生成されてるが、認証後にデータ保存がされてなかったので修正**  
  `app/controllers/google_login_api_controller.rb`の`callback`メソッド内を修正
  - `find_or_create_by`の`create`で保存がされてなかった
  - 今回`create`するには`name`カラム、`password`カラムが必要
    - `password`カラムは gem 'devise'  に必要なカラム
    - パスワードはデバイスの`friendly_token`で生成
  - `find_or_create_by`をブロックの書き方にし、`create`に２つの属性を渡した
  - 念の為、`begin rescue`で例外エラーを特定しやすい書き方をしてます


___
 [**テストで実装した内容**](https://github.com/pakira-56A/SAMPLE/pull/3)
参考にした記事：[Googleログインボタンを実装](https://zenn.dev/yoiyoicho/articles/c44a80e4bb4515#google%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B)
