### PR TITLE
`custom_alerts.css`が読み込めないエラーを修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,5 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import 'custom_alerts';

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,4 +2,4 @@
 @tailwind components;
 @tailwind utilities;
 
-@import 'custom_alerts.css';
+@import 'custom_alerts';


### PR DESCRIPTION
**`custom_alerts.css`が読み込めないエラーがあったので修正**
- `app/assets/stylesheets/application.tailwind.css`の`import`を削除
___
エラーだった時の認証前後の検証ツールと、Renderのログ
[![Image from Gyazo](https://i.gyazo.com/cdc7ec4c80d094703055f94b6a6988ba.png)](https://gyazo.com/cdc7ec4c80d094703055f94b6a6988ba)