### PR TITLE
fix/戻るボタン・フラッシュメッセージをテンプレ化。ヘッダーコンテンツの配置を整理 close #182

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,5 +167,5 @@ https://www.figma.com/design/HgPujRv8Tli2qBWqlzYeyY/Untitled?node-id=0-1&t=1UjNV
 ___
 ### ER図
 https://dbdiagram.io/d/あるある神経衰弱-670531e2fb079c7ebdbde9aa  
-[![Image from Gyazo](https://i.gyazo.com/8da5cb459e8d9f8e483d7aab1515702b.png)](https://gyazo.com/8da5cb459e8d9f8e483d7aab1515702b)
+[![Image from Gyazo](https://i.gyazo.com/ce46be1621b9e6237feccefeb5654acc.png)](https://gyazo.com/ce46be1621b9e6237feccefeb5654acc)
 ____

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
   <header>
     <%= render 'shared/header' %>
   </header>
+  <%= render 'shared/flash_message' %>
 
   <body class="bg-custom-yellow">
     <%= yield %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,12 @@
+<% if notice.present? %>
+    <div class="flex inset-0 justify-center items-center mt-4">
+    <p class="py-2 px-3 bg-green-50 text-green-500 font-medium rounded-lg inline-block" id="notice">
+    <%= notice %></p></div>
+<% end %>
+
+
+<% if alert.present? %>
+    <div class="flex inset-0 justify-center items-center mt-4">
+    <p class="py-2 px-3 bg-orange-50 text-red-500 font-bold rounded-lg border-2 border-orange-400 inline-block" id="alert">
+    <%= alert %></p></div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,63 +1,62 @@
-<div class="flex justify-between items-center">
-    <div class="grid grid-cols-3 flex mt-6">
-        <div class="flex">
+<header class="flex justify-between items-center h-16 bg-yellow-50 shadow-md">
+
+    <!-- 左側：遊び方 -->
+    <div class="flex-1 flex justify-start">
         <button class="font-bold text-2xl whitespace-nowrap text-[#F50968] hover:text-[#5099ff] drop-shadow-lg ml-6"
-        onclick="howto.showModal()">遊び方</button>
+                onclick="howto.showModal()">遊び方</button>
         <dialog id="howto" class="modal">
-            <div class="modal-box fixed  transform  bg-white rounded-lg max-w-[600px] p-2 z-50 drop-shadow-lg">
-                <p class="py-2">
-                <h3 class="text-pink-500 font-bold p-2 text-xl text-center text-[#ff0090]">🥳　遊び方　🥳</h3>
-                <div class="howto-text text-[#ff5900] text-left whitespace-nowrap leading-400 px-6 py-8 left-2">
-                    <div class="font-bold text-center">あらゆる界隈をすこーし探求できるゲーム</div>
-                    <br>
-                    ①あるあるを知りたい界隈を入力！<br>
-                    ＡＩがあるあるを生成してくれるよ
-                    <div class="flex">
-                    <%= image_tag 'header/AI-search.png', width: '60', height: '60' %>
-                    <%= image_tag 'header/AI-lines.jpeg', width: '320', height: '60' %>
-                    </div>
-                    <br>
-                    <div class="flex">②<%= image_tag 'header/start-button.png', class: 'rounded-circle mr-2', width: '130', height: '2' %>で</div>
-                    札をめくって、あるあるのペアを作ろう！
-                    <div class="flex space-x-3">
-                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                        <%= image_tag 'header/card-2.jpeg',  width: '60', height: '60' %>
-                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                        <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
-                        <%= image_tag 'header/pea.jpeg',  width: '150', height: '60' %>
-                        <br>
-                    </div>
-                    <div class="flex space-x-3">
-                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                        <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
-                        <%= image_tag 'header/card.png',  width: '60', height: '60' %>
-                        <%= image_tag 'header/pea-lines.png',  width: '200', height: '60' %>
-                    </div>
-                    <br>
-                    <div class="flex space-x-3">
-                        ③左上の <%= image_tag 'header/menu/menus.svg', width: '30', height: '30' %> から
-                        </div>
-                        誰かのあるあるで遊んだり、自作してシェアしよう！
-                        </div>
-                    </div>
-                <form method="dialog" class="modal-backdrop mix-blend-multiply bg-[#FFAB508D]" onclick="howto.close()"></form>
+        <div class="modal-box fixed transform bg-white rounded-lg max-w-[600px] p-2 z-50 drop-shadow-lg">
+            <p class="py-2">
+            <h3 class="text-pink-500 font-bold p-2 text-xl text-center text-[#ff0090]">🥳　遊び方　🥳</h3>
+            <div class="howto-text text-[#ff5900] text-left whitespace-nowrap leading-400 px-6 py-8 left-2">
+                <div class="font-bold text-center">あらゆる界隈をすこーし探求できるゲーム</div>
+                <br>
+                ①あるあるを知りたい界隈を入力！<br>
+                ＡＩがあるあるを生成してくれるよ
+                <div class="flex">
+                <%= image_tag 'header/AI-search.png', width: '60', height: '60' %>
+                <%= image_tag 'header/AI-lines.jpeg', width: '320', height: '60' %>
                 </div>
-                </p>
+                <br>
+                <div class="flex">②<%= image_tag 'header/start-button.png', class: 'rounded-circle mr-2', width: '130', height: '2' %>で</div>
+                札をめくって、あるあるのペアを作ろう！
+                <div class="flex space-x-3">
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card-2.jpeg',  width: '60', height: '60' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
+                <%= image_tag 'header/pea.jpeg',  width: '150', height: '60' %>
+                <br>
+                </div>
+                <div class="flex space-x-3">
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/card-1.jpeg', class: 'border-4 border-yellow-300 rounded-lg', width: '60', height: '60' %>
+                <%= image_tag 'header/card.png',  width: '60', height: '60' %>
+                <%= image_tag 'header/pea-lines.png',  width: '200', height: '60' %>
+                </div>
+                <br>
+                <div class="flex space-x-3">
+                ③左上の <%= image_tag 'header/menu/menus.svg', width: '30', height: '30' %> から
+                </div>
+                誰かのあるあるで遊んだり、自作してシェアしよう！
             </div>
-    </dialog>
+            </p>
+        </div>
+        <form method="dialog" class="modal-backdrop mix-blend-multiply bg-[#FFAB508D]" onclick="howto.close()"></form>
+        </dialog>
+    </div>
 
+    <!-- 中央：ログイン状態に応じたコンテンツを実装予定 -->
+    <div class="flex-1 flex justify-center">
 
-    <div class="google_login_button mt-6 mr-6">
         <script src="https://accounts.google.com/gsi/client" async defer></script>
-
         <div id="g_id_onload"
             data-client_id="<%= ENV['GOOGLE_CLIENT_ID'] %>"
-            data-login_uri=
-            "<%= Rails.env.development? ? 'http://localhost:3000/google_login_api/callback' : 'https://aruaru-game.onrender.com/google_login_api/callback' %>"
+            data-login_uri="http://localhost:3000/google_login_api/callback"
             data-auto_prompt="false">
         </div>
-        <div class="g_id_signin bg-custom-yellow"
+        <div class="g_id_signin bg-yellow-50"
             data-type="standard"
             data-size="large"
             data-theme="outline"
@@ -68,35 +67,33 @@
         </div>
     </div>
 
-
-    <nav class="flex justify-end">
-            <div class="menus cursor-pointer drop-shadow-lg mr-6 mt-6">
-                <a id="menus-button" class="menus-button">
-                <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id:'image-menus-button'%>
-                </a>
-                <div id="menus-area" class="fixed max-w-[400px] top-[55px] right-[4px] bg-white rounded-[10px] drop-shadow-lg">
-                    <div class="flex flex-col list-none whitespace-nowrap py-4 px-6">
-                        <div class="menu-list1 text-[#019c8f] hover:text-[#00e297]">
-                            <a href="/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4 pr-8">
-                                <%= image_tag 'header/menu/menu-1.svg', width: '30', height: '30',id:'image-menu1' %>
-                                誰かが作ったあるあるで遊ぶ</a></div>
-                        <div class="menu-list2 text-[#0088D0] hover:text-[#00c5ff]" >
-                            <a href="/user/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
-                                <%= image_tag 'header/menu/menu-2.svg', width: '25', height: '25',id:'image-menu2' %>
-                                自分であるあるを作って投稿</a></div>
-                        <div class="menu-list3 text-[#DF5656] hover:text-[#fe9898]" >
-                            <a href="/bookmarks" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
-                                <%= image_tag 'header/menu/menu-3.svg', width: '25', height: '25',id:'image-menu3' %>
-                                お気に入りの界隈をみる</a></div>
-                        <div class="menu-list4 text-[#818181] hover:text-[#b7b7b7]" >
-                            <a href="/settings" class="font-bold flex justify-start items-center no-underline gap-2">
-                                <%= image_tag 'header/menu/menu-4.svg', width: '25', height: '25',id:'image-menu4' %>
-                                設定</a></div>
-                    </div>
+    <!-- 右端：メニュー -->
+    <div class="flex-1 flex justify-end">
+        <div class="menus cursor-pointer drop-shadow-lg mr-6">
+        <a id="menus-button" class="menus-button">
+            <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id:'image-menus-button'%>
+        </a>
+            <div id="menus-area" class="fixed max-w-[400px] top-[55px] right-[4px] bg-white rounded-[10px] drop-shadow-lg">
+                <div class="flex flex-col list-none whitespace-nowrap py-4 px-6">
+                    <div class="menu-list1 text-[#019c8f] hover:text-[#00e297]">
+                        <a href="/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4 pr-8">
+                        <%= image_tag 'header/menu/menu-1.svg', width: '30', height: '30',id:'image-menu1' %>
+                        誰かが作ったあるあるで遊ぶ</a></div>
+                    <div class="menu-list2 text-[#0088D0] hover:text-[#00c5ff]" >
+                        <a href="/user/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
+                        <%= image_tag 'header/menu/menu-2.svg', width: '25', height: '25',id:'image-menu2' %>
+                        自分であるあるを作って投稿</a></div>
+                    <div class="menu-list3 text-[#DF5656] hover:text-[#fe9898]" >
+                        <a href="/bookmarks" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
+                        <%= image_tag 'header/menu/menu-3.svg', width: '25', height: '25',id:'image-menu3' %>
+                        お気に入りの界隈をみる</a></div>
+                    <div class="menu-list4 text-[#818181] hover:text-[#b7b7b7]" >
+                        <a href="/settings" class="font-bold flex justify-start items-center no-underline gap-2">
+                        <%= image_tag 'header/menu/menu-4.svg', width: '25', height: '25',id:'image-menu4' %>
+                        設定</a></div>
                 </div>
             </div>
-        </nav>
-
         </div>
     </div>
-</div>
+
+</header>

--- a/app/views/shared/_toppage_backbutton.html.erb
+++ b/app/views/shared/_toppage_backbutton.html.erb
@@ -1,0 +1,4 @@
+<%= link_to 'トップへ戻る', '/toppage',
+class: 'btn  rounded-lg shadow-md py-2 mt-4 px-5
+    text-orange-500 font-light border-stone-200 bg-white
+    hover:text-red-500 hover:font-bold hover:bg-slate-100 '%>

--- a/app/views/tops/my_index.html.erb
+++ b/app/views/tops/my_index.html.erb
@@ -1,9 +1,3 @@
-
-<% if notice.present? %>
-<p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice">
-<%= notice %></p>
-<% end %>
-
 <h1>Tops#my_index</h1>
 <p>Find me in app/views/tops/my_index.html.erb</p>
 <div>

--- a/app/views/tops/policy.html.erb
+++ b/app/views/tops/policy.html.erb
@@ -48,7 +48,6 @@
         <p class="mb-4">お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、<a href="https://docs.google.com/forms/d/18ZqQchVUQhLMo8hjqlj0_ig74KAnTrmrV46cCb-L0MQ/prefill" class="text-blue-500 hover:underline">お問い合わせフォーム</a>よりご連絡ください。</p>
         <p class="mb-4 text-right">2024年10月29日 制定</p>
     </section>
-    <%= link_to 'トップへ戻る', '/toppage',
-    class: 'nav-link text-orange-500 hover:text-red-500 hover:font-bold no-underline
-        border-solid border border-stone-200 rounded-lg bg-white'%>
+
+    <%= render 'shared/toppage_backbutton' %>
 </section>

--- a/app/views/tops/term.html.erb
+++ b/app/views/tops/term.html.erb
@@ -257,7 +257,6 @@
     <section>
         <h2 class="mb-4 text-right">2024年10月29日 制定</h2>
     </section>
-    <%= link_to 'トップへ戻る', '/toppage',
-    class: 'nav-link text-orange-500 hover:text-red-500 hover:font-bold no-underline
-        border-solid border border-stone-200 rounded-lg bg-white'%>
+
+    <%= render 'shared/toppage_backbutton' %>
 </section>


### PR DESCRIPTION
**該当issue**： #182 
**できるようになったこと**
- ユーザーにとっては操作性に変わりありません
_______
## 実装内容
**テンプレを生成**
  - `app/views/shared/_flash_message.html.erb`：フラッシュメッセージ
    - 参考記事：[【Rails】フラッシュメッセージ実装](https://zenn.dev/h_hana/articles/8d1062943ad6af)
  - `app/views/shared/_toppage_backbutton.html.erb`：`トップへ戻る`ボタン  

**フラッシュメッセージを配置していた記述を削除**
  - `app/views/tops/my_index.html.erb`    

**フラッシュメッセージを表示する配置を`render`で指定**
  - `app/views/layouts/application.html.erb`  

**戻るボタンを配置していた記述を、`render`呼び出しに置き換え**
  - `app/views/tops/term.html.erb`
  -  `app/views/tops/term.html.erb`  

**ヘッダーのコンテンツの配置を整理**
**READMEを修正**：ER図の`Posts`テーブル（現時点で未実装）のカラム名を修正
