### PR TITLE
Google認証後の遷移先を分けた。Dockerで`web`コンテナが立ちあがない問題を修正。インデント整理

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
  # 環境構築：-b 0.0.0.0 -p 3000を追加
 web: env RUBY_DEBUG_OPEN=true bin/rails server  -b 0.0.0.0 -p 3000
 js: yarn build --watch
-css: yarn build:css
+css: yarn build:css --watch

--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -1,31 +1,31 @@
 class GoogleLoginApiController < ApplicationController
-  require 'googleauth/id_tokens/verifier'
+    require 'googleauth/id_tokens/verifier'
 
-  # g_csrf_tokenの検証がOKだった場合、callbackアクションが実行
-  protect_from_forgery except: :callback
-  # verify_g_csrf_tokenをメソッドを実行
-  before_action :verify_g_csrf_token
+    # g_csrf_tokenの検証がOKだった場合、callbackアクションが実行
+    protect_from_forgery except: :callback
+    # verify_g_csrf_tokenをメソッドを実行
+    before_action :verify_g_csrf_token
 
-  def callback
-    payload = Google::Auth::IDTokens.verify_oidc(params[:credential], aud: ENV['GOOGLE_CLIENT_ID'])
-    begin
-      generated_password = Devise.friendly_token
-      user = User.find_or_create_by!(email: payload['email']) do |u|
-        u.password = generated_password
-        u.name = payload['name']
-      end
-      session[:user_id] = user.id
-      redirect_to after_login_path, notice: 'ログインできたよ'
-    rescue StandardError => e
-      pp e
+    def callback
+        payload = Google::Auth::IDTokens.verify_oidc(params[:credential], aud: ENV['GOOGLE_CLIENT_ID'])
+        begin
+        generated_password = Devise.friendly_token
+        user = User.find_or_create_by!(email: payload['email']) do |u|
+            u.password = generated_password
+            u.name = payload['name']
+        end
+        session[:user_id] = user.id
+        redirect_to after_login_path, notice: 'ログインできたよ'
+        rescue StandardError => e
+        pp e
+        end
     end
-  end
 
-  private
+    private
 
-  def verify_g_csrf_token
-    return unless cookies['g_csrf_token'].blank? || params[:g_csrf_token].blank? || cookies['g_csrf_token'] != params[:g_csrf_token]
+    def verify_g_csrf_token
+        return unless cookies['g_csrf_token'].blank? || params[:g_csrf_token].blank? || cookies['g_csrf_token'] != params[:g_csrf_token]
 
-    redirect_to root_path, notice: '不正なアクセスです'
-  end
+        redirect_to root_path, notice: '不正なアクセスです'
+    end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -53,7 +53,8 @@
         <script src="https://accounts.google.com/gsi/client" async defer></script>
         <div id="g_id_onload"
             data-client_id="<%= ENV['GOOGLE_CLIENT_ID'] %>"
-            data-login_uri="http://localhost:3000/google_login_api/callback"
+            data-login_uri=
+            "<%= Rails.env.development? ? 'http://localhost:3000/google_login_api/callback' : 'https://aruaru-game.onrender.com/google_login_api/callback' %>"
             data-auto_prompt="false">
         </div>
         <div class="g_id_signin bg-yellow-50"


### PR DESCRIPTION
**できるようになったこと**
- **Google認証後、遷移先を本番環境とローカル環境で分けた**
  - `app/views/shared/_header.html.erb`
  - ログインボタンの`data-login_uri`を三項演算子に修正
- **Dockerで`web`コンテナが立ちあがない問題を修正**
  - `Procfile.dev`の`css: yarn build:css`に、`--watch`を追加
  - この記載がなくて`web`コンテナが立ち上がりきらなかった
- **インデント整理**
  - `app/controllers/google_login_api_controller.rb`
 ____
Google認証に関する修正なのに、`feature/posts`ブランチで`push`してしまいました。すみません。