### PR TITLE
投稿機能#1,2：`誰かが投稿した界隈`一覧実装。ヘッダーのメニューをDaisyUIのドロップダウンに書換。`db/seeds.rb`でユーザーと投稿を生成。

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 /* メニュー */
-.menus-button :hover{ content: url('header/menu/menus-hover.svg');}
+.menus-btn :hover{ content: url('header/menu/menus-hover.svg');}
 .menu-list1 a:hover #image-menu1 { content: url('header/menu/menu-1-hover.svg');}
 .menu-list2 a:hover #image-menu2 { content: url('header/menu/menu-2-hover.svg');}
 .menu-list3 a:hover #image-menu3 { content: url('header/menu/menu-3-hover.svg');}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,5 @@
+class PostsController < ApplicationController
+  def index
+    @posts = Post.includes(:user)
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,10 @@
+class Post < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :aruaru_one, presence: true, length: { maximum: 30 }
+  validates :aruaru_two, presence: true, length: { maximum: 30 }
+  validates :aruaru_three, presence: true, length: { maximum: 30 }
+  validates :aruaru_four, presence: true, length: { maximum: 30 }
+  validates :aruaru_five, presence: true, length: { maximum: 30 }
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
 
   validates :uid, presence: true, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
+  has_many :posts, dependent: :destroy
+
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.name = auth.info.name

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,24 @@
+<div class="card bg-green-50 hover:bg-white rounded-lg shadow-md hover:shadow-none text-nowrap">
+    <div class="card-body">
+        <div id="post-id-<%= post.id %>">
+            <ul class="list-inline text-slate-400">
+                <li><i class="bi bi-person"></i><%= post.user.name %>さん作</li>
+            </ul>
+            <%= link_to post.title, '#' ,
+                class: "card-title font-bold text-lime-800 hover:text-orange-500 drop-shadow-md hover:drop-shadow-none" %>
+            <div class="text-lime-600 pt-2">界隈のあるあるで遊ぶ</div>
+
+            <!-- 編集・削除機能は未実装です -->
+            <div class="card-actions justify-end">
+                <%= link_to '#', id: 'button-edit-#{post.id}' do %>
+                    <i class="bi bi-pencil-fill"></i>
+                <% end %>
+                <%= link_to '#', id: 'button-delete-#{post.id}', method: :delete, data: {confirm: ''} do %>
+                    <i class="bi bi-trash-fill"></i>
+                <% end %>
+            </div>
+
+        </div>
+    </div>
+</div>
+<br>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,30 @@
+<div class="container py-4">
+
+    <form>
+        <div class="flex mb-6 ml-8 gap-2">
+            <input class="form-control" placeholder="まだ未実装だよ！" type="search"/>
+            <input type="submit" value="検索" class="btn px-3"/>
+        </div>
+    </form>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="row">
+
+                <% if @posts.present? %>
+                    <div class="flex flex-wrap justify-center gap-4">
+                        <%= render @posts %>
+                    </div>
+                <% else %>
+                    <div class="mb-3 text-center">まだ投稿がないよ！投稿しよう！</div>
+                <% end %>
+
+            </div>
+        </div>
+    </div>
+
+</div>
+
+<div class="pl-8">
+    <%= render 'shared/toppage_backbutton' %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -70,30 +70,38 @@
 
     <!-- 右端：メニュー -->
     <div class="flex-1 flex justify-end">
-        <div class="menus cursor-pointer drop-shadow-lg mr-6">
-        <a id="menus-button" class="menus-button">
-            <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id:'image-menus-button'%>
-        </a>
-            <div id="menus-area" class="fixed max-w-[400px] top-[55px] right-[4px] bg-white rounded-[10px] drop-shadow-lg">
-                <div class="flex flex-col list-none whitespace-nowrap py-4 px-6">
-                    <div class="menu-list1 text-[#019c8f] hover:text-[#00e297]">
-                        <a href="/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4 pr-8">
-                        <%= image_tag 'header/menu/menu-1.svg', width: '30', height: '30',id:'image-menu1' %>
-                        誰かが作ったあるあるで遊ぶ</a></div>
-                    <div class="menu-list2 text-[#0088D0] hover:text-[#00c5ff]" >
-                        <a href="/user/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
+
+        <div class="dropdown dropdown-bottom dropdown-end">
+            <div tabindex="0" role="button"
+                class="menus-btn bg-yellow-50 hover:bg-yellow-50 border-0 hover:border-none mr-8">
+            <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id: 'image-menus-button', class: 'drop-shadow-md hover:drop-shadow-none'%>
+            </div>
+            <ul tabindex="0"
+            class="dropdown-content menu bg-white rounded-box z-[1] w-[300px] p-2 mt-6 mr-4 shadow-lg">
+                <li>
+                    <div class="menu-list1 text-[#019c8f] hover:text-[#00e297] hover:bg-white">
+                    <%= link_to image_tag('header/menu/menu-1.svg', width: '30', height: '30', id: 'image-menu1') + '誰かが作ったあるあるで遊ぶ',
+                        posts_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2 pr-8" %>
+                </li>
+                <li>
+                    <div class="menu-list2 text-[#0088D0] hover:text-[#00c5ff] hover:bg-white" >
+                        <a href="/user/index" class="font-bold flex justify-start items-center no-underline gap-2 pb-2">
                         <%= image_tag 'header/menu/menu-2.svg', width: '25', height: '25',id:'image-menu2' %>
                         自分であるあるを作って投稿</a></div>
-                    <div class="menu-list3 text-[#DF5656] hover:text-[#fe9898]" >
-                        <a href="/bookmarks" class="font-bold flex justify-start items-center no-underline gap-2 pb-4">
+                </li>
+                <li>
+                    <div class="menu-list3 text-[#DF5656] hover:text-[#fe9898] hover:bg-white" >
+                        <a href="/bookmarks" class="font-bold flex justify-start items-center no-underline gap-2 pb-2">
                         <%= image_tag 'header/menu/menu-3.svg', width: '25', height: '25',id:'image-menu3' %>
                         お気に入りの界隈をみる</a></div>
-                    <div class="menu-list4 text-[#818181] hover:text-[#b7b7b7]" >
+                </li>
+                <li>
+                    <div class="menu-list4 text-[#818181] hover:text-[#b7b7b7] hover:bg-white" >
                         <a href="/settings" class="font-bold flex justify-start items-center no-underline gap-2">
                         <%= image_tag 'header/menu/menu-4.svg', width: '25', height: '25',id:'image-menu4' %>
                         設定</a></div>
-                </div>
-            </div>
+                </li>
+            </ul>
         </div>
     </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,12 +23,12 @@ module Myapp
       g.test_framework nil
     end
 
+    config.time_zone = 'Tokyo'
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,6 @@ Rails.application.routes.draw do
   get "/policy", to: "tops#policy"
   get "/term", to: "tops#term"
   get "/toppage", to: "tops#toppage"
+
+  resources :posts, only: %i[index]
 end

--- a/db/migrate/20241105072501_create_posts.rb
+++ b/db/migrate/20241105072501_create_posts.rb
@@ -1,0 +1,17 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+
+      t.string :title, null: false
+      t.string :aruaru_one, null: false
+      t.string :aruaru_two, null: false
+      t.string :aruaru_three, null: false
+      t.string :aruaru_four, null: false
+      t.string :aruaru_five, null: false
+
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_26_095238) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_05_072501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "aruaru_one", null: false
+    t.string "aruaru_two", null: false
+    t.string "aruaru_three", null: false
+    t.string "aruaru_four", null: false
+    t.string "aruaru_five", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -30,4 +43,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_26_095238) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "posts", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,28 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+ActiveRecord::Base.transaction do
+
+	10.times do |n|
+    User.create!(
+        name: "テスト#{n+1}",
+        email: "test#{n+1}@example.com",
+        password: "password")
+    end
+
+    user_ids = User.ids
+
+    20.times do |n|
+        user = User.find_by(id: user_ids.sample)
+        if user
+            user.posts.create!(
+                title: "タイトル#{n}",
+                aruaru_one: "あるある1#{n + 1}",
+                aruaru_two: "あるある2:#{n + 1}",
+                aruaru_three: "あるある3:#{n + 1}",
+                aruaru_four: "あるある4:#{n + 1}",
+                aruaru_five: "あるある5:#{n + 1}")
+        else
+            Rails.logger.error "ユーザーが見つからないエラー"
+        end
+    end
+end
+
+Rails.logger.debug "#{User.count}さんと、投稿「#{Post.count}」がDBに入った"


### PR DESCRIPTION
## 投稿一覧の実装（[コミット](90f0bc8e504e369ecb49e6fa80f10d2f7139330c)） 該当issue： #63 
- **`Post`モデル・`Posts`テーブルを生成**
  - `app/models/post.rb`
  - `db/migrate/20241105072501_create_posts.rb`
  - `db/schema.rb`
- **ルーティングを設定**
  - `config/routes.rb`に`resources :posts, only: %i[index]`追記
- **設定したルーティングに対応するアクションを用意**
  - `app/controllers/posts_controller.rb`に`index`アクションを追記
- **ビュー**
  - `app/views/posts/_post.html.erb`：投稿一覧の画面を生成
  - `app/views/posts/index.html.erb`の中に、`render`で`_post.html.erb`を呼び出してる
  - `app/views/shared/_header.html.erb`
    - `body`の後ろに重なって表示されてしまうので、メニューを[DaisyUIのドロップダウン](https://daisyui.com/components/dropdown/#dropdown-bottom--aligns-to-end:~:text=Dropdown%20bottom%20/%20aligns%20to%20end)に書き換え
    - メニューリストから、投稿一覧へ遷移するよう書き換え
  - `app/assets/stylesheets/application.tailwind.css`
    - メニューリストの書き換えに伴い、メニューボタンの`id`名を変更

**しなかったこと**
- 検索機能：検索フォームとボタンだけは用意しました、本リリース後に実装予定

**できるようになったこと**
- 投稿される界隈あるあるを一覧で見られる
  - http://localhost:3000/posts （投稿一覧画面）
  - https://aruaru-game.onrender.com/posts
[![Image from Gyazo](https://i.gyazo.com/d8460346219aa49046b5ca3cd77e87fa.png)](https://gyazo.com/d8460346219aa49046b5ca3cd77e87fa)
____
## ローカルにて、`seeds.rb`でユーザーと投稿レコードを生成　該当issue： #188
**`db/seeds.rb`で生成したもの**（[コミット](https://github.com/pakira-56A/aruaru-game/commit/2f2de5ae239710bece67336deb8b64e557e1d4c10)）
- `user`10人を生成
- `post`20件を生成


**しなかったこと**
- `gem 'faker'を使ったランダムなカラム値のデータ生成
  - 本番環境に使ったランダムなカラム値の`user`と`post`を生成すると、削除が大変だと思いGemを使いませんでした
  - 本番環境で`rails db:seed`を実行しない前提なので、カラム値には`#{n + 1}`を多用してます

- `gem 'kaminari'`（ページネーション機能）の実装
  - 投稿一覧に19件しか表示がされませんでした
  `gem 'kaminari'`を実装しようかと思いましたが、今回はMVPリリースを急ぐのでパスしました
  - 実装時の参考記事に目星はつけました  
  [【Rails】gem 'kaminari' と Tailwind CSS + daisyUI でページネーションをカスタマイズする](https://qiita.com/yuki31100725/items/f8f3ddeaa990de342d11)
