### PR TITLE
ログアウト実装、未ログイン/ログイン済かでヘッダーの表示を変化 close #191

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -50,22 +50,28 @@
     <!-- 中央：ログイン状態に応じたコンテンツを実装予定 -->
     <div class="flex-1 flex justify-center">
 
-        <script src="https://accounts.google.com/gsi/client" async defer></script>
-        <div id="g_id_onload"
-            data-client_id="<%= ENV['GOOGLE_CLIENT_ID'] %>"
-            data-login_uri=
-            "<%= Rails.env.development? ? 'http://localhost:3000/google_login_api/callback' : 'https://aruaru-game.onrender.com/google_login_api/callback' %>"
-            data-auto_prompt="false">
-        </div>
-        <div class="g_id_signin bg-yellow-50"
-            data-type="standard"
-            data-size="large"
-            data-theme="outline"
-            data-text="signin"
-            data-shape="pill"
-            data-logo_alignment="left"
-            data-width="60">
-        </div>
+        <% if user_signed_in? %>
+            <%= link_to root_path, class: "flex items-center drop-shadow-md shadow-pink-500 hover:drop-shadow-none" do %>
+                <%= image_tag 'logo-clear.png', alt: 'Logo', class: 'h-12 w-auto' %>
+            <% end %>
+        <% else %>
+            <script src="https://accounts.google.com/gsi/client" async defer></script>
+            <div id="g_id_onload"
+                data-client_id="<%= ENV['GOOGLE_CLIENT_ID'] %>"
+                data-login_uri=
+                "<%= Rails.env.development? ? 'http://localhost:3000/google_login_api/callback' : 'https://aruaru-game.onrender.com/google_login_api/callback' %>"
+                data-auto_prompt="false">
+            </div>
+            <div class="g_id_signin bg-yellow-50"
+                data-type="standard"
+                data-size="large"
+                data-theme="outline"
+                data-text="signin"
+                data-shape="pill"
+                data-logo_alignment="left"
+                data-width="60">
+            </div>
+        <% end %>
     </div>
 
     <!-- 右端：メニュー -->
@@ -101,6 +107,16 @@
                         <%= image_tag 'header/menu/menu-4.svg', width: '25', height: '25',id:'image-menu4' %>
                         設定</a></div>
                 </li>
+
+                <% if user_signed_in? then %>
+                    <li>
+                    <div class="menu-list5 text-[#B4B4B4] hover:text-[#DBAAFF] pt-2 hover:bg-white">
+                        <div class="font-bold flex justify-start items-center no-underline gap-2" >
+                            <%= link_to "　　ログアウト", destroy_user_session_path, method: :delete %>
+                        </div>
+                    </div>
+                    </li>
+                <% end %>
             </ul>
         </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   #OmniAuth：認証成功時の処理
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_scope :user do
+    get '/users/sign_out' => 'devise/sessions#destroy'
+  end
 
   root "tops#toppage"
 


### PR DESCRIPTION
# ログアウト機能
# 未ログイン/ログイン済かでヘッダーの表示を変化
**該当issue**： #191
**できるようになったこと**
- ログイン済ユーザーのみ利用できる機能
  - ヘッダーのロゴをクリックするとトップページに遷移できる
  - ログアウトできる
____
**未ログイン/ログイン済かの状態で表示が変わる仕様**
  - `app/views/shared/_header.html.erb`
- **未ログインユーザーに表示するもの**
  - Google認証ボタン
  [![Image from Gyazo](https://i.gyazo.com/ef90c14403895b1a3d8b80c3c6cc8c53.png)](https://gyazo.com/ef90c14403895b1a3d8b80c3c6cc8c53)
- **ログイン済みユーザーに表示するもの**
  - ルートに遷移するロゴ
  [![Image from Gyazo](https://i.gyazo.com/3a036f420087d1dd57b25b900d996bfb.png)](https://gyazo.com/3a036f420087d1dd57b25b900d996bfb)
  - ルートに遷移するログアウト（メニューリスト）
  [![Image from Gyazo](https://i.gyazo.com/75efd3506325c48696867e8900c59e6e.png)](https://gyazo.com/75efd3506325c48696867e8900c59e6e)

**参考記事**
- [【解決策】`devise`のログアウト機能でのエラー](https://qiita.com/s_gossipgirl/items/0522dece7574c94287ca)
____