### PR TITLE
Google認証#8 ：ログイン後の遷移先をルートに変更 close #195

### DIFF
--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -15,7 +15,7 @@ class GoogleLoginApiController < ApplicationController
         u.name = payload['name']
       end
       sign_in(user)
-      redirect_to after_login_path, notice: 'ログインできたよ'
+      redirect_to root_path, notice: 'ログインできたよ！右上のメニューから遊んでね！'
     rescue StandardError => e
       pp e
     end
@@ -26,6 +26,6 @@ class GoogleLoginApiController < ApplicationController
   def verify_g_csrf_token
     return unless cookies['g_csrf_token'].blank? || params[:g_csrf_token].blank? || cookies['g_csrf_token'] != params[:g_csrf_token]
 
-    redirect_to root_path, notice: '不正なアクセスです'
+    redirect_to root_path, alert: '不正なアクセスです'
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     return unless @post.user != current_user
 
-    flash[:alert] = "この界隈あるあるを、神経衰弱で遊ぶ？"
+    flash[:alert] = 'この界隈あるあるを、神経衰弱で遊ぶ？'
     redirect_to posts_path
   end
 
@@ -17,36 +17,36 @@ class PostsController < ApplicationController
     @post = Post.new
   end
 
+  def edit
+    @post = current_user.posts.find(params[:id])
+  end
+
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      flash[:notice] = "投稿したよ"
+      flash[:notice] = '投稿したよ'
       redirect_to posts_path
     else
-      flash.now[:alert] = "全て入力してね！30文字までだよ！"
+      flash.now[:alert] = '全て入力してね！30文字までだよ！'
       render :new, status: :unprocessable_entity
     end
-  end
-
-  def edit
-    @post = current_user.posts.find(params[:id])
   end
 
   def update
     @post = current_user.posts.find(params[:id])
     if @post.update(post_params)
-        flash[:notice] = "更新したよ"
-        redirect_to post_path(@post)
+      flash[:notice] = '更新したよ'
+      redirect_to post_path(@post)
     else
-        flash.now[:alert] = "全て入力してね！30文字までだよ！"
-        render :edit, status: :unprocessable_entity
+      flash.now[:alert] = '全て入力してね！30文字までだよ！'
+      render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     post = current_user.posts.find(params[:id])
     post.destroy!
-    flash[:notice] = "消したよ〜 また投稿してね！"
+    flash[:notice] = '消したよ〜 また投稿してね！'
     redirect_to posts_path
   end
 

--- a/app/views/tops/my_index.html.erb
+++ b/app/views/tops/my_index.html.erb
@@ -1,6 +1,0 @@
-<h1>Tops#my_index</h1>
-<p>Find me in app/views/tops/my_index.html.erb</p>
-<div>
-    <script src="https://accounts.google.com/gsi/client" async defer></script>
-    <h1 class="font-bold text-4xl">ログイン後のページ</h1>
-</div>

--- a/app/views/tops/toppage.html.erb
+++ b/app/views/tops/toppage.html.erb
@@ -8,6 +8,9 @@
         <title>トップページ</title>
     </head>
 
+
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+
     <body class="text-center">
 
     <div class="flex justify-center">
@@ -17,7 +20,7 @@
         <form id="myForm" class="font-light text-lg text-[#0090e3] ">
             <label for="inputData" class="block mb-2 text-center">どの界隈のあるあるで遊ぶ？🤔</label>
                 <div class="flex justify-center mb-4">
-                    <input type="text" placeholder="例）ONEPIECE：イーストブルー編" id="inputData" name="inputData"
+                    <input type="text" placeholder="未実装だよ！待っててね！" id="inputData" name="inputData"
                         class="w-[360px] p-2 border-4 border-[#ffa463] rounded text-left font-family-['BIZ UDGothic'] placeholder-[#cecece]" />
                 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   root "tops#toppage"
 
   post "google_login_api/callback", to: "google_login_api#callback"
-  get "/after_login", to: "tops#my_index"
+  get "/after_login", to: "tops#toppage" #アクセスされる時のため、一応残しています
 
   get "/policy", to: "tops#policy"
   get "/term", to: "tops#term"


### PR DESCRIPTION
**該当issue**： #195
**できるようになったこと**
- ログイン後トップページに遷移するので、すぐにAIに界隈名を渡して遊べる（AI機能は未実装）
[![Image from Gyazo](https://i.gyazo.com/02211a26c2d993faf0171d01e59d5b75.png)](https://gyazo.com/02211a26c2d993faf0171d01e59d5b75)
____
**ログイン後の遷移先を、トップページに変更** 
- `app/controllers/google_login_api_controller.rb`：不正ログイン時のメッセージをアラートに変更
- `app/views/tops/toppage.html.erb`：ログイン後の遷移先を変更
- `config/routes.rb`：ログイン後の遷移先を変更
- `app/views/tops/toppage.html.erb`の入力フォームのプレスホルダーを「未実装だよ」に書き換えた

**しなかったこと**
- 自作した界隈一覧の作成
  - ルーティング設定の時点でつまづき、MVPリリースを優先することにした
____
以下のファイルは**Lintチェックにる変更**や、誤字の修正であり。今回の実装とは無関係
- `app/controllers/posts_controller.rb`：Lintチェック（`edit`が移動、文字列を`"`から`'`に変更）
____
