### PR TITLE
投稿機能#5：一覧へ戻るボタン作成・設置 close #71

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -24,7 +24,7 @@
             </div>
         <% end %>
 
-    <%= render 'shared/toppage_backbutton' %>
+    <%= render 'shared/index_backbutton' %>
     <%= f.submit nil, class: "btn  text-white font-semibold rounded-lg mt-4
             drop-shadow-lg hover:drop-shadow-none bg-[#0088D0] hover:bg-orange-500" %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,5 +22,7 @@
                 class: "bg-white border-sky-200 rounded-md border-2 py-1.5 px-4 border-2") %>
             <% end %>
         </div>
+
+        <%= render 'shared/index_backbutton' %>
     </div>
 </div>

--- a/app/views/shared/_index_backbutton.html.erb
+++ b/app/views/shared/_index_backbutton.html.erb
@@ -1,0 +1,4 @@
+<%= link_to '一覧へ戻る', posts_path,
+class: 'btn rounded-lg py-2 mt-4 px-5
+    text-orange-500 font-light border-stone-200 bg-white shadow-md
+    hover:text-red-500 hover:font-bold hover:bg-slate-100 hover:shadow-none'%>


### PR DESCRIPTION
**該当issue**： #71
**できるようになったこと**
- 投稿の作成・詳細・編集画面から、投稿一覧へ戻れる
[![Image from Gyazo](https://i.gyazo.com/e94f85a44a2dd3066e817e96b8f519ac.png)](https://gyazo.com/e94f85a44a2dd3066e817e96b8f519ac)

____
**一覧へ戻るボタン作成・設置**
- `app/views/shared/_index_backbutton.html.erb`：`一覧へ戻る`ボタンのテンプレ

- テンプレを呼び出してるビュー
  - `app/views/posts/show.html.erb`
  - `app/views/posts/_form.html.erb`

**しなかったこと**
- 自作した界隈一覧の作成
  - ルーティング設定の時点でつまづき、MVPリリースを優先することにした
____
