### PR TITLE
投稿関連修正：未ログインユーザーは、投稿一覧を全投稿一覧として見れるようにする。`一覧へ戻る`ボタンを二分 close #206

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,9 +2,11 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, only: %i[myindex new show edit update create]
 
   def index
-    @posts = Post.includes(:user)
-    # 以下、カレントユーザーがいる前提の書き方なので、未ログインユーザーがindexアクションを閲覧できなくなる
-    # @posts = Post.where.not(user_id: current_user.id)
+    if user_signed_in?
+      @posts = Post.where.not(user_id: current_user.id)
+    else
+      @posts = Post.includes(:user)
+    end
   end
 
   def myindex

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -26,8 +26,8 @@
             </div>
         <% end %>
 
-    <%= render 'shared/index_backbutton' %>
     <%= f.submit nil, class: "btn  text-white font-semibold rounded-lg mt-4
             drop-shadow-lg hover:drop-shadow-none bg-[#0088D0] hover:bg-orange-500" %>
+    <%= render 'shared/index_backbutton' %>
 
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -7,7 +7,7 @@
                 <%= link_to post.title, start_game_path(post),
                     class: "post-box-title font-bold pt-2
                         text-cyan-800 hover:text-orange-500 drop-shadow-md hover:drop-shadow-none" %>
-                <div class="text-cyan-600 pt-2">界隈のあるあるで遊ぶ</div>
+                <div class="text-cyan-600 pt-2">あるあるで遊ぶ</div>
 
                 <div class="flex justify-end gap-4 pt-2">
                     <%= link_to post_path(post), id: 'button-show-#{post.id}' do %>
@@ -36,7 +36,7 @@
                 <%= link_to post.title, start_game_path(post),
                     class: "post-box-title font-bold pt-2
                         text-lime-800 hover:text-orange-500 drop-shadow-md hover:drop-shadow-none" %>
-                <div class="text-lime-600 pt-2">界隈のあるあるで遊ぶ</div>
+                <div class="text-lime-600 pt-2">あるあるで遊ぶ</div>
             </div>
         </div>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,5 +17,6 @@
 </div>
 
 <div class="pl-8">
+    <%= render 'shared/index_backbutton' %>
     <%= render 'shared/toppage_backbutton' %>
 </div>

--- a/app/views/posts/myindex.html.erb
+++ b/app/views/posts/myindex.html.erb
@@ -20,5 +20,6 @@
 </div>
 
 <div class="pl-8">
+    <%= render 'shared/index_backbutton' %>
     <%= render 'shared/toppage_backbutton' %>
 </div>

--- a/app/views/shared/_index_backbutton.html.erb
+++ b/app/views/shared/_index_backbutton.html.erb
@@ -1,4 +1,8 @@
-<%= link_to '一覧へ戻る', posts_path,
-class: 'btn rounded-lg py-2 mt-4 px-5
-    text-orange-500 font-light border-stone-200 bg-white shadow-md
-    hover:text-red-500 hover:font-bold hover:bg-slate-100 hover:shadow-none'%>
+<% link_classes = 'btn rounded-lg py-2 mt-2 p-2 border-stone-200 bg-slate-50
+                    shadow-md hover:shadow-none hover:bg-white hover:font-bold' %>
+
+<%= link_to '誰かが作ったあるある一覧へ戻る', posts_path,
+    class: "#{link_classes} text-[#019c8f] font-light hover:text-[#00e297]" %>
+<br>
+<%= link_to '自作したあるある一覧へ戻る', myindex_posts_path,
+    class: "#{link_classes} text-[#00cee8] font-light hover:text-[#6eefff]" %>


### PR DESCRIPTION
**該当issue** ：#206
____
# 修正：未ログインユーザーは、投稿一覧を全投稿一覧として見れるようにする
未ログインユーザーが、他人投稿一覧をアクセスした際
エラー画面になってしまうのを、[`feature/game`ブランチで応急処置](https://github.com/pakira-56A/aruaru-game/pull/208#issuecomment-2476973449)しました。
それを修正しました。

### 実行した手順
- `app/controllers/posts_controller.rb`：修正
  - `if`文でログイン済みかを確認し
  未ログインユーザーは、全投稿を表示させ
  ログイン済みユーザーは、他者投稿を表示させる


# `一覧へ戻る`ボタンを２つに分離
プルリク #205 にて、他人の投稿一覧と自作投稿一覧を分けたので
`一覧へ戻る`ボタンを以下の２種に分離させた
- `誰かが作ったあるある一覧へ戻る`ボタン
- `自作したあるある一覧へ戻る`ボタン
### 実行した手順
- `app/views/shared/_index_backbutton.html.erb`を編集
  - 一覧へ戻るボタンを、他人一覧と自作一覧の２つに分けた
- `app/views/posts/_form.html.erb`
  - 投稿/更新ボタンと、２つの一覧へ戻るボタンの位置を入れ替え
- `app/views/posts/myindex.html.erb`：２つの一覧へ戻るボタンを追加
- `app/views/posts/index.html.erb`：２つの一覧へ戻るボタンを追加
___
**今回の修正には無関係の修正** 
- `app/views/posts/_post.html.erb`：投稿ボックスのテキストを変更