### PR TITLE
投稿関連修正：投稿や編集後の遷移先変更、ゲーム画面へ遷移する際のビュー・CSSを修正 close #213

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -10,10 +10,10 @@
 .menu-list4 a:hover #image-menu4 { content: url('header/menu/menu-4-hover.svg');}
 
 /* 投稿の詳細・ゲーム・編集・削除ボタン */
-.post-show :hover { content: url('post/post-show-hover.svg');}
-.post-game :hover { content: url('post/post-game-hover.svg');}
-.post-edit :hover{ content: url('post/post-edit-hover.svg');}
-.post-delete :hover { content: url('post/post-delete-hover.svg');}
+.post-show :hover #button-show{ content: url('post/post-show-hover.svg');}
+.post-game :hover #button-game { content: url('post/post-game-hover.svg');}
+.post-edit :hover #button-edit{ content: url('post/post-edit-hover.svg');}
+.post-delete :hover #button-delete{ content: url('post/post-delete-hover.svg');}
 
 /* ゲーム画面 （Tailwindに書き換えられず） */
 #panel {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,7 +29,7 @@ class PostsController < ApplicationController
     @post = current_user.posts.build(post_params)
     if @post.save
       flash[:notice] = '投稿したよ！'
-      redirect_to posts_path
+      redirect_to myindex_posts_path(@post)
     else
       flash.now[:alert] = '全て入力してね！40文字までだよ！'
       render :new, status: :unprocessable_entity
@@ -40,7 +40,7 @@ class PostsController < ApplicationController
     @post = current_user.posts.find(params[:id])
     if @post.update(post_params)
       flash[:notice] = '更新したよ'
-      redirect_to post_path(@post)
+      redirect_to myindex_posts_path(@post)
     else
       flash.now[:alert] = '全て入力してね！30文字までだよ！'
       render :edit, status: :unprocessable_entity
@@ -51,7 +51,7 @@ class PostsController < ApplicationController
     post = current_user.posts.find(params[:id])
     post.destroy!
     flash[:notice] = '消したよ〜 また投稿してね！'
-    redirect_to posts_path
+    redirect_to myindex_posts_path(@post)
   end
 
   private

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -10,7 +10,7 @@
         placeholder: "例:ONEPIECEイーストブルー編" %>
     </div>
 
-    <%= f.label :aruarus, "あるあるを５つ入力してね！", class: "label text-[#0088D0] pb-0" %>
+    <%= f.label :aruarus, "あるあるを５つ、40文字以内で入力してね！", class: "label text-[#0088D0] pb-0" %>
         <% [:aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five].each_with_index do |field, index| %>
             <div class="mt-2">
             <%= f.text_area field,

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,45 +1,43 @@
 <% if current_user == post.user %>
-
     <!-- カレントユーザーが自作した投稿（myindex） -->
-    <div class="post-box bg-cyan-50 hover:bg-white rounded-lg shadow-md hover:shadow-none text-nowrap">
-        <div class="post-box-body p-4">
-            <div id="post-id-<%= post.id %>">
-                <%= link_to post.title, start_game_path(post),
-                    class: "post-box-title font-bold pt-2
-                        text-cyan-800 hover:text-orange-500 drop-shadow-md hover:drop-shadow-none" %>
-                <div class="text-cyan-600 pt-2">あるあるで遊ぶ</div>
+    <div class="post-box-body bg-[#fbffff] rounded-lg p-2">
+        <%= link_to start_game_path(post),
+        class: "block post-box bg-cyan-50 hover:bg-white rounded-lg
+            shadow-md hover:shadow-none text-nowrap hover:border-2 hover:border-orange-400" do %>
+                <div id="post-id-<%= post.id %>">
+                    <div class="post-box-title font-bold p-2 pb-0 text-cyan-800 drop-shadow-md group-hover:drop-shadow-none">
+                        <%= post.title %></div>
+                    <div class="text-cyan-600 p-2 text-xs">あるあるで遊ぶ</div>
 
-                <div class="flex justify-end gap-4 pt-2">
-                    <%= link_to post_path(post), id: 'button-show-#{post.id}' do %>
-                        <%= image_tag 'post/post-show.svg', width: '25', height: '25', class: "post-game drop-shadow-md hover:drop-shadow-none" %>
-                    <% end %>
-                    <%= link_to edit_post_path(post), id: 'button-edit-#{post.id}' do %>
-                        <%= image_tag 'post/post-edit.svg', width: '25', height: '25', class: "post-edit drop-shadow-md hover:drop-shadow-none" %>
-                    <% end %>
-                    <%= link_to post_path(post), id: 'button-delete-#{post.id}', data: { turbo_method: :delete, turbo_confirm: "えぇ〜 消しちゃうの？" } do %>
-                        <%= image_tag 'post/post-delete.svg', width: '25', height: '25', class: "post-delete drop-shadow-md hover:drop-shadow-none" %>
-                    <% end %>
+                    <div class="flex justify-end gap-4 pt-2">
+                        <% actions = [
+                            { path: post_path(post), id: "button-show", image: 'post/post-show.svg', class: 'post-game' },
+                            { path: edit_post_path(post), id: "button-edit", image: 'post/post-edit.svg', class: 'post-edit' },
+                            { path: post_path(post), id: "button-delete", image: 'post/post-delete.svg', class: 'post-delete', data: { turbo_method: :delete, turbo_confirm: "えぇ〜 消しちゃうの？" } }
+                        ] %>
+                        <% actions.each do |action| %>
+                            <%= link_to image_tag(action[:image], width: '25', height: '25', class: "#{action[:class]} drop-shadow-md hover:drop-shadow-none"), action[:path], id: action[:id], data: action[:data] %>
+                        <% end %>
+                    </div>
                 </div>
-            </div>
-        </div>
+        <% end %>
     </div>
 
 <% else %>
 
-		<!-- 他のユーザーが投稿した一覧（index） -->
-    <div class="post-box bg-green-50 hover:bg-white rounded-lg shadow-md hover:shadow-none text-nowrap">
+    <!-- 他のユーザーが投稿した一覧（index） -->
+    <%= link_to start_game_path(post),
+        class: "block post-box bg-green-50 hover:bg-white rounded-lg shadow-md hover:shadow-none text-nowrap border-2 hover:border-2 hover:border-orange-400" do %>
         <div class="post-box-body p-4">
             <div id="post-id-<%= post.id %>">
-                <ul class="list-inline text-slate-400">
-                    <li><i class="bi bi-person"></i><%= post.user.name %>さんの思う</li>
-                </ul>
-                <%= link_to post.title, start_game_path(post),
-                    class: "post-box-title font-bold pt-2
-                        text-lime-800 hover:text-orange-500 drop-shadow-md hover:drop-shadow-none" %>
-                <div class="text-lime-600 pt-2">あるあるで遊ぶ</div>
+                <ul class="list-inline text-slate-400 text-xs"><%= post.user.name %>さんの思う</ul>
+                <div class="post-box-title font-bold pt-2 text-lime-800 group-hover:text-orange-500 drop-shadow-md group-hover:drop-shadow-none">
+                    <%= post.title %>
+                </div>
+                <div class="text-lime-600 pt-2 text-xs">あるあるで遊ぶ</div>
             </div>
         </div>
-    </div>
+    <% end %>
 
 <% end %>
 <br>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,14 +2,24 @@
 
     <%= render 'search_form' %>
 
-    <div class="col-12">
-        <div class="row">
+    <div class="flex flex-col items-center">
+        <div class="flex items-center mb-2">
+            <div class="text-3xl font-bold text-green-600">みんなが思う</div>
+            <div class="text-lg font-bold text-lime-500 ml-2"><%= "界隈あるある一覧" %></div>
+        </div>
+        <div class="text-lg font-bold text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
+
             <% if @posts.present? %>
                 <div class="flex flex-wrap justify-center gap-4">
                     <%= render @posts %>
                 </div>
             <% else %>
                 <div class="mb-3 text-center">まだ投稿がないよ！投稿しよう！</div>
+                <div class="menu-list2 bg-white rounded-lg p-2 text-[#0088D0] hover:text-[#00c5ff]
+                    border-2 hover:border-orange-400 drop-shadow-md hover:drop-shadow-none" >
+                <%= link_to image_tag('header/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
+                    new_post_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2" %>
+                </div>
             <% end %>
         </div>
     </div>

--- a/app/views/posts/myindex.html.erb
+++ b/app/views/posts/myindex.html.erb
@@ -14,6 +14,11 @@
             </div>
         <% else %>
             <div class="mb-3 text-center">まだ投稿がないよ！投稿しよう！</div>
+            <div class="menu-list2 bg-white rounded-lg p-2 text-[#0088D0] hover:text-[#00c5ff]
+                border-2 hover:border-orange-400 drop-shadow-md hover:drop-shadow-none" >
+            <%= link_to image_tag('header/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
+                new_post_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2" %>
+            </div>
         <% end %>
     </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -73,27 +73,27 @@
             class="dropdown-content menu bg-white rounded-box z-[1] w-[300px] p-2 mt-6 mr-4 shadow-lg">
                 <li>
                     <div class="menu-list1 text-[#019c8f] hover:text-[#00e297] hover:bg-white">
-                    <%= link_to image_tag('header/menu/menu-1.svg', width: '30', height: '30', id: 'image-menu1') + '誰かが作ったあるあるで遊ぶ',
-                        posts_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2 pr-8" %>
+                    <%= link_to image_tag('header/menu/menu-1.svg', width: '30', height: '30', id: 'image-menu1') + 'みんなが思うあるあるで遊ぶ',
+                        posts_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2" %>
                 </li>
                 <li>
                     <div class="menu-list2 text-[#0088D0] hover:text-[#00c5ff] hover:bg-white" >
                     <%= link_to image_tag('header/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
-                        new_post_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2 pr-8" %>
+                        new_post_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2" %>
                     </div>
                 </li>
 
                 <li>
                     <div class="menu-list3 text-[#00cee8] hover:text-[#6eefff] hover:bg-white" >
                     <%= link_to image_tag('header/menu/menu-3.svg', width: '25', height: '25', id: 'image-menu3') + '自作したあるある一覧・設定',
-                        myindex_posts_path(@post), class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2 pr-8" %>
+                        myindex_posts_path(@post), class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2" %>
                     </div>
                 </li>
                 <!--未実装のリンク -->
                 <li>
                     <div class="menu-list4 text-[#DF5656] hover:text-[#fe9898] hover:bg-white" >
                         <%= link_to image_tag('header/menu/menu-4.svg', width: '25', height: '25', id: 'image-menu4') + 'お気に入りの界隈',
-                            root_path, class: "font-bold flex justify-start items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2 pr-8",
+                            root_path, class: "font-bold flex justify-start items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2 pb-2",
                             onclick: "alert('未実装だよ！待っててね！'); return false;" %>
                     </div>
                 </li>

--- a/app/views/shared/_index_backbutton.html.erb
+++ b/app/views/shared/_index_backbutton.html.erb
@@ -1,7 +1,7 @@
 <% link_classes = 'btn rounded-lg py-2 mt-2 p-2 border-stone-200 bg-slate-50
                     shadow-md hover:shadow-none hover:bg-white hover:font-bold' %>
 
-<%= link_to '誰かが作ったあるある一覧へ戻る', posts_path,
+<%= link_to 'みんなが思うあるある一覧へ戻る', posts_path,
     class: "#{link_classes} text-[#019c8f] font-light hover:text-[#00e297]" %>
 <br>
 <%= link_to '自作したあるある一覧へ戻る', myindex_posts_path,


### PR DESCRIPTION
# 投稿や編集後の遷移先変更、ゲーム画面へ遷移する際のビュー・CSSを修正 
**該当issue**： #213
**できるようになったこと**
- 投稿一覧（他者投稿・自作共に）で、投稿からゲーム画面へ行くホバーやクリックがわかりにくかったのを修正
  - http://localhost:3000/posts （他者投稿一覧）
  - https://aruaru-game.onrender.com/posts （他者投稿一覧）
   - http://localhost:3000/posts/myindex （自作投稿一覧）
  - https://aruaru-game.onrender.com/posts/myindex （自作投稿一覧）
[![Image from Gyazo](https://i.gyazo.com/9bef8a5b54feb2acd4812ecf2167a4ff.png)](https://gyazo.com/9bef8a5b54feb2acd4812ecf2167a4ff)
- 投稿一覧（他者投稿・自作共に）で、投稿が存在しない場合は投稿画面に遷移するボタンを表示
[![Image from Gyazo](https://i.gyazo.com/f09a2987104f7885bdd07e13255e23ac.png)](https://gyazo.com/f09a2987104f7885bdd07e13255e23ac)
- メニュー項目：「誰かが作ったあるあるで遊ぶ」から「みんなが思うあるあるで遊ぶ」に変更
- 一覧へ戻るボタン名：「誰かが作ったあるある一覧へ戻る」から「みんなが思うあるある一覧へ戻る」に変更
[![Image from Gyazo](https://i.gyazo.com/5dca3501e3bdc3cb712cda6de73fa7a5.png)](https://gyazo.com/5dca3501e3bdc3cb712cda6de73fa7a5)


____
**実装**
- **コントローラー**
  - `app/controllers/posts_controller.rb`
    - 投稿・更新・削除が成功後、遷移先を`他者投稿一覧`から`自作一覧`に変更
- **ビュー**
  - `app/views/posts/_post.html.erb`：投稿をホバーした時のわかりにくさを解消
  - ` app/assets/stylesheets/application.tailwind.css`
    - 投稿詳細・編集・削除ボタンにホバー時に別画像を表示するためにidを指定（結局反映されず）
- **ビュー：投稿に関してユーザーを誘導**
  - `app/views/posts/_form.html.erb`：投稿画面で「40文字以内で入力してね」アナウンス
  - `app/views/posts/index.html.erb`
    - 「ゆかりがない界隈でも遊んでみよう」アナウンス
    - 投稿がない場合は投稿ボタンを表示
  - `app/views/posts/myindex.html.erb`：投稿がない場合は投稿ボタンを表示
- **ビュー：メニュー項目名を変更**
  - `app/views/shared/_header.html.erb`
    - ：「誰かが作ったあるあるで遊ぶ」から「みんなが思うあるあるで遊ぶ」に変更
    - CSSを調整
  - `app/views/shared/_index_backbutton.html.erb`
    - 「誰かが作ったあるある一覧へ戻る」から「みんなが思うあるある一覧へ戻る」に変更
___
## 今後修正予定
  - `app/controllers/posts_controller.rb`で
    - 投稿・更新・削除が成功後、遷移先を`他者投稿一覧`から`自作一覧`に変更したために
 成功時のフラッシュメッセージが表示されなくなってしまった。
