### PR TITLE
ユーザー名変更機能 close #219

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::Base
+
+    # deviseコントローラを使う前に、deviseコントローラーが真なら以下のアクションを実行する
+    before_action :configure_permitted_parameters, if: :devise_controller?
+
+    private
+
+    def configure_permitted_parameters
+        # 情報更新時にnameの取得を許可
+        devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+    end
+
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,12 +1,19 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  def build_resource(hash = {})
-    hash[:uid] = User.create_unique_string
-    super
-  end
 
-  def update_resource(resource, params)
-    return super if params['password'].present?
+    protected
 
-    resource.update_without_password(params.except('current_password'))
-  end
+    def update_resource(resource, params)
+        if resource.update_without_password(params)
+            true
+        else
+            flash.now[:alert] = "お名前を入力してね"
+            false
+        end
+    end
+
+    def after_update_path_for(resource)
+        flash[:notice] = "OK！きみは、#{resource.name}さんだね！"
+        myindex_posts_path
+    end
+
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="flex justify-center items-center mt-6">
+    <div id="profile" class="area w-80 md:w-96 bg-base-100 rounded-lg">
+        <div class="area-body items-center text-center p-4">
+        <div class="flex">
+            <%= form_with model: @user, url: user_registration_path, method: :put do |f| %>
+                <div class="m-2">
+
+                    <%= f.label :name, "きみのお名前は？", class: "text-xl text-cyan-700 font-bold" %>
+                    <%= f.text_field :name,
+                        class: "input input-bordered border-2 border-sky-300
+                                rounded-md w-60 text-orange-500 font-bold" %>
+                </div>
+
+                <%= f.submit "変更",
+                    class: "btn text-blue-600 bg-cyan-300 hover:bg-cyan-200 font-bold
+                            drop-shadow-md hover:drop-shadow-none" %>
+
+                <div class="flex justify-end pr-4">
+                    <%= link_to 'キャンセル', myindex_posts_path,
+                        class: "text-sm text-blue-600 hover:text-blue-500 hover:font-bold drop-shadow-md hover:drop-shadow-none" %>
+                </div>
+                <% end %>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,6 +1,6 @@
 <form>
-    <div class="flex mb-6 ml-8 gap-2">
-        <input class="form-control placeholder:text-[#C7C7C7]" placeholder="まだ未実装だよ！" type="search"/>
-        <input type="submit" value="検索" class="btn px-3"/>
+    <div class="flex justify-start mb-2 pl-2 gap-1">
+        <input class="form-control p-0 pl-2 w-40" placeholder="まだ未実装だよ！" type="search"/>
+        <input type="submit" value="検索" class="btn btn-sm px-3"/>
     </div>
 </form>

--- a/app/views/shared/_index_backbutton.html.erb
+++ b/app/views/shared/_index_backbutton.html.erb
@@ -1,8 +1,8 @@
-<% link_classes = 'btn rounded-lg py-2 mt-2 p-2 border-stone-200 bg-slate-50
+<% link_classes = 'btn btn-sm rounded-lg py-2 mt-2 p-2 border-stone-200 bg-slate-50
                     shadow-md hover:shadow-none hover:bg-white hover:font-bold' %>
 
-<%= link_to 'みんなが思うあるある一覧へ戻る', posts_path,
+<%= link_to 'みんなが思うあるある一覧へ', posts_path,
     class: "#{link_classes} text-[#019c8f] font-light hover:text-[#00e297]" %>
-<br>
-<%= link_to '自作したあるある一覧へ戻る', myindex_posts_path,
+    <br>
+<%= link_to '自作したあるある一覧へ', myindex_posts_path,
     class: "#{link_classes} text-[#00cee8] font-light hover:text-[#6eefff]" %>

--- a/app/views/shared/_toppage_backbutton.html.erb
+++ b/app/views/shared/_toppage_backbutton.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'トップへ戻る', root_path,
-class: 'btn rounded-lg py-2 mt-4 px-5
+<%= link_to 'トップへ', root_path,
+class: 'btn btn-sm rounded-lg mt-4
     text-orange-500 font-light border-stone-200 bg-white shadow-md
     hover:text-red-500 hover:font-bold hover:bg-slate-100 hover:shadow-none'%>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -1,6 +1,10 @@
 <div class="container py-4">
 
-    <%= render 'search_form' %>
+    <div class="flex gap-2">
+        <%= render 'search_form' %>
+        <%= link_to "お名前変える？", edit_user_registration_path,
+            class: "btn btn-sm text-blue-600 bg-cyan-200 hover:bg-white shadow-md hover:shadow-none" %>
+    </div>
 
     <div class="flex flex-col items-center">
         <div class="flex items-center mb-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   #OmniAuth：認証成功時の処理
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: {
+    sessions: "users/sessions",
+    registrations: "users/registrations" }
+
   devise_scope :user do
     get '/users/sign_out' => 'devise/sessions#destroy'
   end


### PR DESCRIPTION
# `devise`でユーザー名変更機能（[コミット](8adff42f63e228cc6a0ed72cf07e2cdb706892cc)）該当issue：#219
**できるようになったこと**
- 自作一覧画面から、登録されたユーザー名を変更できるようになった
    - http://localhost:3000/users/edit （ユーザー名変更画面）
    - https://aruaru-game.onrender.com/users/edit （ユーザー名変更画面）

[![Image from Gyazo](https://i.gyazo.com/2d396a3a3c6e5e295c0346e31585c7b5.png)](https://gyazo.com/2d396a3a3c6e5e295c0346e31585c7b5)
____
**実装**
参考記事：[`devise` ユーザー情報表示・編集・削除機能](https://qiita.com/wa-chan222/items/e2a81f4b247ae7a383f7)
　　　　　[`devise controller`を使うためのルーティング変更](https://qiita.com/saitok7/items/ae7c57e26037115ed2fc#3-2-devise-controller%E3%82%92%E4%BD%BF%E3%81%86%E3%81%9F%E3%82%81%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0%E5%A4%89%E6%9B%B4)
- **ルーティング**
  - `config/routes.rb`：deviseコントローラーを使う設定を追加
- **コントローラー**
  - `app/controllers/users/registrations_controller.rb`：
    - ユーザー情報更新時にパスワードは不要だと設定
    - 更新後の処理を設定
  - `app/controllers/application_controller.rb`：ユーザー名更新する為に行う確認と許可/取得を設定
- **ビュー**
  - `app/views/devise/registrations/edit.html.erb`を生成：ユーザー名編集画面
  - `app/views/users/posts/index.html.erb`：ユーザー名変更ボタンを追記
  - 
**しなかったこと**
- ユーザー情報詳細画面の用意
  - 自作一覧で名前変更ボタン押し、すぐ編集画面、変更成功後は自作一覧に戻る
  という動作がスムーズだと思い、用意しなかった。
- アカウントの削除画面の作成
  - 不要な機能だと思い、実装しなかった。
____
以下のファイルの変更は、今回の実装とは無関係
- `app/views/posts/_search_form.html.erb`：CSS調整
- `app/views/shared/_index_backbutton.html.erb`：ボタンのテキスト変更
- `app/views/shared/_toppage_backbutton.html.erb`：ボタンのテキスト変更
____
