### PR TITLE
修正：投稿がない場合のビューをテンプレ化。不要な記載を削除。CSS整理。 close #86

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -4,10 +4,9 @@ class GamesController < ApplicationController
     @post = Post.find(params[:id])
     Rails.logger.info("ポストID: #{@post.id} を取得")
 
-    if @post
-      ogp_image_url = generate_and_save_ogp(@post)
-      set_meta_tags(og: { image: ogp_image_url }, twitter: { image: ogp_image_url })
-    end
+    return unless @post
+    ogp_image_url = generate_and_save_ogp(@post)
+    set_meta_tags(og: { image: ogp_image_url }, twitter: { image: ogp_image_url })
   end
 
   private

--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -14,18 +14,11 @@ class GoogleLoginApiController < ApplicationController
         u.password = generated_password
         u.name = payload['name']
       end
-      sign_in(user)
-
-      # 保存したURLがあればそこにリダイレクト、なければposts_pathに遷移
-      redirect_to_location = stored_location_for(user) || posts_path
-      # posts_pathに遷移するならメッセージを追加
-      if redirect_to_location == posts_path
-        flash[:notice] = 'ログインできたよ！どのあるあるで遊ぶ？'
-      end
-      redirect_to redirect_to_location
+      sign_in(user) # 自動ログインに変更
+      redirect_to posts_path, notice: "ログインできたよ！どのあるあるで遊ぶ？"
     rescue StandardError => e
       pp e
-      redirect_to root_path, alert: 'ログインに失敗したよ。もう一度試してみてね！'
+      redirect_to root_path, alert: "ログインに失敗したよ。もう一度試してみてね！"
     end
   end
 

--- a/app/views/posts/_no_posts.html.erb
+++ b/app/views/posts/_no_posts.html.erb
@@ -1,0 +1,9 @@
+<div class="text-center mb-3 text-gray-500">まだないよ！投稿しよう！</div>
+<div class="menu-list2" >
+    <%= link_to image_tag('header/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
+        new_post_path,
+        class: "btn btn-md items-center no-underline rounded-lg w-48 px-2 mb-2 p-0 gap-2
+                font-bold text-nowrap text-[#0088D0] hover:text-[#00c5ff]
+                bg-white hover:bg-white border-2 hover:border-orange-400
+                drop-shadow-md hover:drop-shadow-none" %>
+</div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,49 +1,47 @@
 <% if current_user == post.user %>
-    <!-- カレントユーザーが自作した投稿（myindex） -->
-    <div class="post-box-body bg-[#fbffff] rounded-lg p-2">
-        <%= link_to start_game_path(post),
-        class: "block post-box bg-cyan-50 hover:bg-white rounded-lg
-            shadow-md hover:shadow-none hover:border-2 hover:border-orange-400" do %>
-                <div id="post-id-<%= post.id %>">
-                    <div class="post-box-title font-bold p-2 pb-0 text-cyan-800 drop-shadow-md group-hover:drop-shadow-none">
-                        <%= post.title %></div>
-                    <div class="text-cyan-600 p-2 text-xs">あるあるで遊ぶ</div>
 
-                    <div class="flex justify-end gap-4 pt-2">
-                        <%= render 'shared/xshare_button', post: post %>
-                        <% buttons = [
-                            { path: post_path(post), id: "image-show", image: 'post/post-show.svg', class: 'post-show pt-0.5' },
-                            { path: edit_post_path(post), id: "image-edit", image: 'post/post-edit.svg', class: 'post-edit' },
-                            { path: post_path(post), id: "image-delete", image: 'post/post-delete.svg', class: 'post-delete', data: { turbo_method: :delete, turbo_confirm: "えぇ〜 消しちゃうの？" } }
-                        ] %>
-                        <% buttons.each do |button| %>
-                            <%= link_to image_tag(button[:image], width: '25', height: '25', class: "#{button[:class]} drop-shadow-md hover:drop-shadow-none"), button[:path], id: button[:id], data: button[:data] %>
-                        <% end %>
-                    </div>
-                </div>
+    <!-- カレントユーザーが自作した投稿（myindex） -->
+    <div class="post-box-body bg-[#fbfbfb] rounded-lg p-2">
+        <%= link_to start_game_path(post),
+            class: "block post-box bg-cyan-50 border-2 border-cyan-100 rounded-lg shadow-md
+                    hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
+            <div id="post-id-<%= post.id %>">
+                <div class="post-box-title font-bold p-2 pb-0 text-cyan-800 drop-shadow-md group-hover:drop-shadow-none">
+                    <%= post.title %></div>
+                <div class="text-cyan-600 p-2 text-xs">あるあるで遊ぶ</div>
+            </div>
         <% end %>
+
+        <div class="flex justify-end gap-4 pt-2">
+            <%= render 'shared/xshare_button', post: post %>
+            <% buttons = [
+                { path: post_path(post), id: "image-show", image: 'post/post-show.svg', class: 'post-show pt-0.5' },
+                { path: edit_post_path(post), id: "image-edit", image: 'post/post-edit.svg', class: 'post-edit' },
+                { path: post_path(post), id: "image-delete", image: 'post/post-delete.svg', class: 'post-delete', data: { turbo_method: :delete, turbo_confirm: "えぇ〜 消しちゃうの？" } }
+            ] %>
+            <% buttons.each do |button| %>
+                <%= link_to image_tag(button[:image], width: '25', height: '25', class: "#{button[:class]} drop-shadow-md hover:drop-shadow-none"), button[:path], id: button[:id], data: button[:data] %>
+            <% end %>
+        </div>
     </div>
 
 <% else %>
 
     <!-- 他のユーザーが投稿した一覧（index） -->
-    <div class="post-box-body bg-[#fbffff] rounded-lg p-2">
+    <div class="post-box-body bg-[#fbfbfb] rounded-lg p-2">
         <%= link_to start_game_path(post),
-            class: "block post-box bg-green-50 hover:bg-white rounded-lg
-                    shadow-md hover:shadow-none hover:border-2 hover:border-orange-400" do %>
-
+            class: "block post-box bg-green-50 border-2 border-green-100 rounded-lg shadow-md
+                    hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
             <div id="post-id-<%= post.id %>">
-            <ul class="list-inline text-slate-400 text-xs p-2 pb-0"><%= post.user.name %>さんの思う</ul>
+                <ul class="list-inline text-slate-400 text-xs p-2 pb-0"><%= post.user.name %>さんの思う</ul>
                 <div class="post-box-title font-bold p-2 pb-0 text-lime-800 drop-shadow-md group-hover:drop-shadow-none">
                     <%= post.title %></div>
                 <div class="text-lime-600 p-2 text-xs">あるあるで遊ぶ</div>
-
-                <div class="flex justify-end gap-4 pt-2">
-                    <%= render 'shared/xshare_button', post: post %>
-                </div>
             </div>
-
         <% end %>
+        <div class="flex justify-end gap-4 pt-2">
+            <%= render 'shared/xshare_button', post: post %>
+        </div>
     </div>
 
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,29 +1,23 @@
 <div class="container py-4">
-
-    <%= render 'search_form' %>
-
     <div class="flex flex-col items-center">
+
         <div class="flex items-center mb-2">
             <div class="text-3xl font-bold text-green-600">みんなが思う</div>
             <div class="text-lg font-bold text-lime-500 ml-2"><%= "界隈あるある一覧" %></div>
         </div>
-        <div class="text-lg font-bold text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
+        <div class="text-md text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
 
             <% if @posts.present? %>
                 <div class="flex flex-wrap justify-center gap-4">
                     <%= render @posts %>
                 </div>
             <% else %>
-                <div class="mb-3 text-center">まだ投稿がないよ！投稿しよう！</div>
-                <div class="menu-list2 bg-white rounded-lg p-2 text-[#0088D0] hover:text-[#00c5ff]
-                    border-2 hover:border-orange-400 drop-shadow-md hover:drop-shadow-none" >
-                <%= link_to image_tag('header/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
-                    new_post_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2" %>
+                <div class="my-10">
+                    <%= render 'no_posts' %>
                 </div>
             <% end %>
         </div>
     </div>
-
 </div>
 
 <div class="pl-8">

--- a/app/views/shared/header/_googleloginbutton_or_logo.html.erb
+++ b/app/views/shared/header/_googleloginbutton_or_logo.html.erb
@@ -1,7 +1,7 @@
 <% if user_signed_in? %>
 
     <%= link_to root_path, class: "flex items-center drop-shadow-md shadow-pink-500 hover:drop-shadow-none" do %>
-        <%= image_tag 'logo-clear.png', alt: 'Logo', class: 'h-12 w-auto' %>
+        <%= image_tag 'logo-clear.png', alt: 'Logo', class: 'h-12 w-12' %>
     <% end %>
 
 <% else %>

--- a/app/views/shared/header/_howto.html.erb
+++ b/app/views/shared/header/_howto.html.erb
@@ -1,4 +1,4 @@
-<button class="font-bold text-2xl whitespace-nowrap text-[#F50968] hover:text-[#5099ff] drop-shadow-lg hover:drop-shadow-none ml-6"
+<button class="font-bold text-lg whitespace-nowrap text-[#F50968] hover:text-[#5099ff] drop-shadow-lg hover:drop-shadow-none"
         onclick="howto.showModal()">遊び方</button>
 
 <dialog id="howto" class="modal">

--- a/app/views/shared/header/_menu.html.erb
+++ b/app/views/shared/header/_menu.html.erb
@@ -1,12 +1,11 @@
 <div class="dropdown dropdown-bottom dropdown-end">
 
-    <div tabindex="0" role="button"
-        class="menus-btn bg-yellow-50 hover:bg-yellow-50 border-0 hover:border-none mr-8">
-    <%= image_tag 'header/menu/menus.svg', width: '40', height: '40', id: 'image-menus-button', class: 'drop-shadow-md hover:drop-shadow-none'%>
+    <div tabindex="0" role="button" class="menus-btn bg-yellow-50 hover:bg-yellow-50 border-0 hover:border-none">
+        <%= image_tag 'header/menu/menus.svg', width: '30', height: '30',id: 'image-menus-button', class: 'drop-shadow-md hover:drop-shadow-none'%>
     </div>
 
     <ul tabindex="0"
-        class="dropdown-content menu bg-white rounded-box z-[1] w-[300px] p-2 mt-6 mr-4 shadow-lg">
+        class="dropdown-content menu bg-white rounded-box z-[1] w-[300px] p-2 mt-6 mr-2 shadow-lg">
 
         <%= render 'shared/header/menu-list' %>
 

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -1,9 +1,7 @@
 <div class="container py-4">
-
-    <div class="flex gap-2">
-        <%= render 'search_form' %>
+    <div class="flex justify-center mb-2">
         <%= link_to "お名前変える？", edit_user_registration_path,
-            class: "btn btn-sm text-blue-600 bg-cyan-200 hover:bg-white shadow-md hover:shadow-none" %>
+            class: "btn btn-sm text-blue-600 border-1 border-white hover:border-cyan-500 bg-cyan-200 hover:bg-white shadow-md hover:shadow-none" %>
     </div>
 
     <div class="flex flex-col items-center">
@@ -17,15 +15,11 @@
                 <%= render @posts %>
             </div>
         <% else %>
-            <div class="mb-3 text-center">まだ投稿がないよ！投稿しよう！</div>
-            <div class="menu-list2 bg-white rounded-lg p-2 text-[#0088D0] hover:text-[#00c5ff]
-                border-2 hover:border-orange-400 drop-shadow-md hover:drop-shadow-none" >
-            <%= link_to image_tag('header/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
-                new_post_path, class: "font-bold text-nowrap flex items-center no-underline drop-shadow-md hover:drop-shadow-none gap-2" %>
+            <div class="my-10">
+                    <%= render 'no_posts' %>
             </div>
         <% end %>
     </div>
-
 </div>
 
 <div class="pl-8">


### PR DESCRIPTION
# 投稿がない場合のビューをテンプレ化。不要な記載を削除。CSS整理。該当issue： #86

**できるようになったこと**
- 投稿が存在しない場合のビューをテンプレ化
  - https://aruaru-game.onrender.com/posts ：他者の投稿一覧
  - https://aruaru-game.onrender.com/posts/myindex ：自作の投稿一覧
- ヘッダーに検索フォームを配置予定なので、ヘッダーコンテンツの配置を一旦整理
[![Image from Gyazo](https://i.gyazo.com/c0bc53feec82d51ffb606ddc7ca790bc.png)](https://gyazo.com/c0bc53feec82d51ffb606ddc7ca790bc)
____
**不要な記載を削除**
- `app/controllers/games_controller.rb`：書き方を変更
- `app/controllers/google_login_api_controller.rb`：不要な記載を削除

**ヘッダーに検索フォームを配置予定なので、ヘッダーコンテンツのCSSを修正**
- `app/views/shared/header/_googleloginbutton_or_logo.html.erb`：ロゴの横幅を修正
- `app/views/shared/header/_howto.html.erb`：`遊び方`の文字サイズを修正
- `app/views/shared/header/_menu.html.erb`：ハンバーガーメニューのアイコンのサイズ、配置を修正

**投稿がない場合のビューをテンプレ化**
- `app/views/posts/_no_posts.html.erb`を生成：「まだ投稿ないよ」テンプレ
- `app/views/posts/index.html.erb`（他者投稿一覧）
  - 検索フォームの呼び出しを削除、「まだ投稿ないよ」テンプレを呼び出し、CSS修正
- `app/views/users/posts/index.html.erb`（自作投稿一覧）
  - 検索フォームの呼び出しを削除、「まだ投稿ないよ」テンプレを呼び出し、CSS修正
___
今回の実装には無関係だが、修正
- `app/views/posts/_post.html.erb`：CSSを修正

