### PR TITLE
投稿画面：オートコンプリートで検索機能を実装 close #87

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'meta-tags', require: 'meta_tags'
 gem 'carrierwave', '~> 3.0'
 gem 'fog-aws'
 
+gem 'ransack'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3", ">= 7.1.3.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -449,6 +453,7 @@ DEPENDENCIES
   pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  ransack
   rspec-rails
   rspec_junit_formatter
   rubocop

--- a/app/assets/images/post/post-search.svg
+++ b/app/assets/images/post/post-search.svg
@@ -1,0 +1,14 @@
+<!--?xml version="1.0" encoding="utf-8"?-->
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512 512" style="width: 16px; height: 16px; opacity: 1;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4B4B4B;}
+</style>
+<g>
+	<path class="st0" d="M376.324,312.508c49.638-78.774,40.238-184.326-28.306-252.871c-79.507-79.515-208.872-79.515-288.388,0
+		c-79.507,79.516-79.507,208.873,0,288.379c68.536,68.544,174.115,77.935,252.88,28.306l135.668,135.676L512,448.186
+		L376.324,312.508z M296.543,296.542c-51.121,51.139-134.308,51.139-185.439,0c-51.121-51.121-51.112-134.299,0.009-185.43
+		c51.122-51.121,134.309-51.13,185.43-0.008C347.665,162.243,347.665,245.421,296.543,296.542z" style="fill: rgb(255, 255, 255);"></path>
+</g>
+</svg>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
   # deviseコントローラを使う前に、deviseコントローラーが真なら以下のアクションを実行する
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_search
 
   private
 
   def configure_permitted_parameters
     # 情報更新時にnameの取得を許可
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  end
+
+  def set_search
+    @q = Post.ransack(params[:q])
   end
 end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
 
 const application = Application.start()
+application.register('autocomplete', Autocomplete)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,8 @@ class Post < ApplicationRecord
   belongs_to :user
 
   mount_uploader :ogp, PostOgpUploader
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ['title']
+  end
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,10 +1,14 @@
-<% if current_user == post.user %>
+<div class="post-box-body bg-[#fbfbfb] rounded-lg p-2">
+    <% if current_user == post.user %>
 
-    <!-- カレントユーザーが自作した投稿（myindex） -->
-    <div class="post-box-body bg-[#fbfbfb] rounded-lg p-2">
+        <!-- カレントユーザーが自作した投稿（myindex） -->
         <%= link_to start_game_path(post),
             class: "block post-box bg-cyan-50 border-2 border-cyan-100 rounded-lg shadow-md
                     hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
+            <!-- 検索結果一覧に表示する場合は、カレントユーザー名を表示 -->
+            <% if request.path == search_posts_path %>
+                <ul class="list-inline text-slate-400 text-xs p-2 pb-0"><%= post.user.name %>さんの思う</ul>
+            <% end %>
             <div id="post-id-<%= post.id %>">
                 <div class="post-box-title font-bold p-2 pb-0 text-cyan-800 drop-shadow-md group-hover:drop-shadow-none">
                     <%= post.title %></div>
@@ -23,17 +27,15 @@
                 <%= link_to image_tag(button[:image], width: '25', height: '25', class: "#{button[:class]} drop-shadow-md hover:drop-shadow-none"), button[:path], id: button[:id], data: button[:data] %>
             <% end %>
         </div>
-    </div>
 
-<% else %>
+    <% else %>
 
-    <!-- 他のユーザーが投稿した一覧（index） -->
-    <div class="post-box-body bg-[#fbfbfb] rounded-lg p-2">
+        <!-- 他のユーザーが投稿した一覧（index） -->
         <%= link_to start_game_path(post),
             class: "block post-box bg-green-50 border-2 border-green-100 rounded-lg shadow-md
-                    hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
+                hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
             <div id="post-id-<%= post.id %>">
-                <ul class="list-inline text-slate-400 text-xs p-2 pb-0"><%= post.user.name %>さんの思う</ul>
+            <ul class="list-inline text-slate-400 text-xs p-2 pb-0"><%= post.user.name %>さんの思う</ul>
                 <div class="post-box-title font-bold p-2 pb-0 text-lime-800 drop-shadow-md group-hover:drop-shadow-none">
                     <%= post.title %></div>
                 <div class="text-lime-600 p-2 text-xs">あるあるで遊ぶ</div>
@@ -42,7 +44,7 @@
         <div class="flex justify-end gap-4 pt-2">
             <%= render 'shared/xshare_button', post: post %>
         </div>
-    </div>
 
-<% end %>
+    <% end %>
+</div>
 <br>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,6 +1,18 @@
-<form>
-    <div class="flex justify-start mb-2 pl-2 gap-1">
-        <input class="form-control p-0 pl-2 w-40" placeholder="まだ未実装だよ！" type="search"/>
-        <input type="submit" value="検索" class="btn btn-sm px-3"/>
-    </div>
-</form>
+<div class="flex pl-2 gap-1">
+    <%= search_form_for @q, url: url do |f| %>
+        <div class="relative flex rounded-md">
+            <%= f.search_field :title_cont,
+                class: "border-gray-200 shadow-md rounded-md p-0 px-2 w-40 pl-2 block
+                        text-md text-orange-500 font-bold focus:ring-pink-500
+                        placeholder:font-normal placeholder:text-gray-400 placeholder:text-xs",
+                        placeholder: "どの界隈名で遊ぶ？" %>
+            <%= f.hidden_field :title %>
+            <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+            <div class="absolute inset-y-0 left-0 flex items-center pointer-events-none pl-4"></div>
+
+            <%= button_tag class: "btn btn-sm border-1 bg-pink-300 hover:bg-pink-200 hover:border-orange-500 px-3 ml-2 shadow-md" do %>
+                <%= image_tag 'post/post-search.svg', alt: 'Search', class: 'h-5 w-5' %>
+            <% end %>
+        </div>
+    <% end %>
+</div>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,16 +1,20 @@
 <div class="flex pl-2 gap-1">
     <%= search_form_for @q, url: url do |f| %>
         <div class="relative flex rounded-md">
-            <%= f.search_field :title_cont,
-                class: "border-gray-200 shadow-md rounded-md p-0 px-2 w-40 pl-2 block
-                        text-md text-orange-500 font-bold focus:ring-pink-500
+            <div data-controller="autocomplete"
+                    data-autocomplete-url-value="<%= autocomplete_posts_path %>"
+                    role="combobox">
+                <%= f.search_field :title_cont, data: { autocomplete_target: 'input' },
+                    class: "border-pink-300 shadow-md rounded-md p-0 px-2 w-32 h-8 pl-2 block
+                        text-md text-orange-500 font-bold
                         placeholder:font-normal placeholder:text-gray-400 placeholder:text-xs",
-                        placeholder: "どの界隈名で遊ぶ？" %>
-            <%= f.hidden_field :title %>
-            <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
-            <div class="absolute inset-y-0 left-0 flex items-center pointer-events-none pl-4"></div>
-
-            <%= button_tag class: "btn btn-sm border-1 bg-pink-300 hover:bg-pink-200 hover:border-orange-500 px-3 ml-2 shadow-md" do %>
+                        placeholder: "どの界隈で遊ぶ？" %>
+                <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+                <ul class="list-group bg-white absolute w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+                <div class="absolute inset-y-0 left-0 flex items-center pointer-events-none pl-4">
+                </div>
+            </div>
+            <%= button_tag class: "btn btn-sm border-1 bg-pink-300 hover:bg-pink-200 hover:border-orange-500 px-3 ml-0.5 shadow-md" do %>
                 <%= image_tag 'post/post-search.svg', alt: 'Search', class: 'h-5 w-5' %>
             <% end %>
         </div>

--- a/app/views/posts/autocomplete.html.erb
+++ b/app/views/posts/autocomplete.html.erb
@@ -1,0 +1,16 @@
+<ul class="list-group absolute md:text-sm max-w-max z-50 mt-2">
+    <% if @posts.present? %>
+        <% @posts.each do |post| %>
+            <li class="autocomplete-item w-56 flex items-center gap-x-3 py-2 px-3
+                    bg-white rounded-md text-sm text-orange-700
+                    hover:bg-pink-100 hover:text-orange-500"
+                    role="option">
+                <%= post.title %>
+            </li>
+        <% end %>
+    <% else %>
+        <li class="autocomplete-item w-56 flex flex-col items-start gap-x-3 py-2 px-3 bg-white rounded-md">
+            <%= render 'no_posts' %>
+        </li>
+    <% end %>
+</ul>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,0 +1,26 @@
+<div class="container py-4">
+
+    <div class="flex flex-col items-center">
+        <div class="flex items-center mb-2">
+            <div class="text-xl font-bold text-fuchsia-400"><%= "見つけた界隈あるある一覧" %></div>
+        </div>
+        <div class="text-md text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
+
+            <% if @posts.present? %>
+                <div class="flex flex-wrap justify-center gap-4">
+                    <%= render @posts %>
+                </div>
+            <% else %>
+                <div class="my-10">
+                    <%= render 'no_posts' %>
+                </div>
+            <% end %>
+        </div>
+    </div>
+
+</div>
+
+<div class="pl-8">
+    <%= render 'shared/index_backbutton' %>
+    <%= render 'shared/toppage_backbutton' %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,17 +1,22 @@
-<header class="flex justify-between items-center h-16 bg-yellow-50 shadow-md">
+<header class="h-16 bg-yellow-50 shadow-md flex justify-between items-center">
 
     <!-- 左側：遊び方 -->
-    <div class="flex-1 flex justify-start">
+    <div class="flex-1 text-center ml-2">
         <%= render 'shared/header/howto' %>
     </div>
 
-    <!-- 中央：ログイン状態に応じたコンテンツを表示 -->
-    <div class="flex-1 flex justify-center">
+    <!-- 中央左：ログイン状態に応じたコンテンツを表示 -->
+    <div class="flex-1 text-center ml-2">
         <%= render 'shared/header/googleloginbutton_or_logo' %>
     </div>
 
+    <!-- 中央右：検索フォーム -->
+    <div class="flex-1 text-center mr-8 h-8">
+        <%= render 'posts/search_form', url: search_posts_path %>
+    </div>
+
     <!-- 右端：メニュー -->
-    <div class="flex-1 flex justify-end">
+    <div class="flex-1 text-center mr-2">
         <%= render 'shared/header/menu' %>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     collection do
       get :myindex
       get :search
+      get :autocomplete
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :posts, only: %i[index new create show edit update destroy] do
     collection do
       get :myindex
+      get :search
     end
   end
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "daisyui": "^4.12.13",
     "esbuild": "^0.21.4",
     "postcss": "^8.4.47",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^3.4.14"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
# 投稿画面：オートコンプリートで検索機能を実装　該当issue：#87
**できるようになったこと**
- どのページからでも投稿を検索できる
  - カレントユーザーの投稿がヒットした場合は、カレントユーザー名が表示
[![Image from Gyazo](https://i.gyazo.com/d36891eba08103aed8e7cf67d5c6e571.gif)](https://gyazo.com/d36891eba08103aed8e7cf67d5c6e571)
  - オートコンプリートは、ひらがな・カタカナ。英語は大文字小文字問わずヒットが表示されます
[![Image from Gyazo](https://i.gyazo.com/b696929f98dac5a4a0f511ac27e4fb74.gif)](https://gyazo.com/b696929f98dac5a4a0f511ac27e4fb74)
  - ヒットしない場合はオートコンプリートにも、新規投稿画面の導線が表示
[![Image from Gyazo](https://i.gyazo.com/a1de1b8839ad25704ebc74bf94d3e524.gif)](https://gyazo.com/a1de1b8839ad25704ebc74bf94d3e524)
____
**実装**
参考資料：[`stimulus-autocomplete`オートコンプリート付き検索機能を実装](https://qiita.com/Yamamoto-Masaya1122/items/879d6eb540ce4e05cfe5)
- **`ransack`と`stimulus-autocomplete`をインストール**
  - `Gemfile`：`ransack`をインストール（`stimulus-rails`は導入済みでした）
  - `stimulus-autocomplete`をインストール
  - `app/javascript/controllers/application.js`：コンポーネントを読ませる追記
- **ルーティング**
  - `config/routes.rb`：`search` `autocomplete`アクションを追加
- **モデル**
  - `app/models/post.rb`：検索する属性を明記
- **コントローラー**
  - `app/controllers/posts_controller.rb`：`search` `autocomplete` `search_posts(query)`アクションを追加 
  - `app/controllers/application_controller.rb`：どのページでも検索可能に
- **ビュー**
  - `app/assets/images/post/post-search.svg`：検索ボタンに使うアイコンを用意
  - `app/views/posts/_search_form.html.erb`を生成：検索フォームのテンプレ
  - ` app/views/posts/autocomplete.html.erb`を生成：オートコンプリート
  - `app/views/posts/search.html.erb`を生成：検索結果一覧
  - `app/views/shared/_header.html.erb`：ヘッダーに検索フォームの呼び出し
  - `app/views/posts/_post.html.erb`：検索結果として表示される際は、カレントユーザー名を表示。

**しなかったこと**
- `Posts`コントローラーの肥大化の解消
  - 後日解消しようと思います。
- ひらがなで検索して、そのカタカナの投稿タイトルが検索結果一覧に表示されること
  - オートコンプリートがあるんだから不要では？という意見が出て断念（余裕があれば解消したい）