### PR TITLE
投稿機能#8：文字数カウンター実装

### DIFF
--- a/app/controllers/search_posts_controller.rb
+++ b/app/controllers/search_posts_controller.rb
@@ -23,14 +23,12 @@ class SearchPostsController < ApplicationController
             "title ILIKE ?",
             "title ILIKE ?",
             "title ILIKE ?",
-            "title ILIKE ?",
             "title ILIKE ?" ]
 
         search_queries = [
             "%#{query}%",
             "%#{query.tr('ぁ-ん', 'ァ-ン')}%",
             "%#{query.tr('ァ-ン', 'ぁ-ん')}%",
-            "%#{query.tr('一-龯', '')}%",
             "%#{query.tr('a-zA-Z', '')}%" ]
         posts = Post.where(conditions.join(" OR "), *search_queries)
         if query.match?(/[a-zA-Z]/)

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,11 +1,13 @@
 import { Application } from "@hotwired/stimulus"
 import { Autocomplete } from 'stimulus-autocomplete'
+import CharacterCounter from '@stimulus-components/character-counter'
 
 const application = Application.start()
 application.register('autocomplete', Autocomplete)
+application.register('character-counter', CharacterCounter)
 
 // Configure Stimulus development experience
-application.debug = false
+application.debug = true  // trueでデバック用のログを出力
 window.Stimulus   = application
 
 export { application }

--- a/app/views/games/start.html.erb
+++ b/app/views/games/start.html.erb
@@ -19,6 +19,8 @@
                 data-aruaru-five="<%= @post.aruaru_five %>">
         </div>
 
-        <%= render 'shared/index_backbutton' %>
+        <div class="mt-8">
+            <%= render 'shared/index_backbutton' %>
+        </div>
     </div>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,33 +2,42 @@
     <%= f.label :title, "界隈名", class: "label text-[#0088D0] pb-0" %>
     <%= f.label :title, "(自動で末尾に「〇〇界隈あるある」とつくよ！）", class: "label text-[#0088D0] text-xs pt-0" %>
     <dr>
-    <div>
-    <%= f.text_area :title,
-        class: "input input-bordered border-2 border-sky-300 rounded-md w-72
-                text-md text-orange-500 font-bold rows-2
-                placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
-        placeholder: "例:ONEPIECEイーストブルー編" %>
+
+    <div class="relative" data-controller="character-counter" data-character-counter-countdown-value="true">
+        <%= f.text_area :title, id: "post_title",
+            class: "input input-bordered border-2 border-sky-300 rounded-md w-72 h-16
+                    text-sm text-orange-500 font-bold rows-2
+                    placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
+            placeholder: "例:ONEPIECEイーストブルー編",
+            data: { character_counter_target: "input" }, maxlength: 40 %>
+        <p class="absolute right-2 bottom-2 text-xs text-green-500">
+            あと <strong data-character-counter-target="counter"></strong> 字まで
+        </p>
     </div>
 
-    <%= f.label :aruarus, "あるあるを５つ、40文字以内で入力してね！", class: "label text-[#0088D0] pb-0 text-sm " %>
+    <%= f.label :aruarus, "あるあるを５つ、入力してね！", class: "label text-[#0088D0] text-sm pb-0" %>
         <% [:aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five].each_with_index do |field, index| %>
-            <div class="mt-2">
-            <%= f.text_area field,
-                class: "input input-bordered border-2 border-sky-300 rounded-md w-72
-                        text-sm text-orange-500 font-bold h-[75px]
-                        placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
-                placeholder: "例:#{['ゾロがまだ陽気',
-                                    '３巻まではSBSないから、すぐ読み終えちゃう',
-                                    'アニメのオープニング『富・名声・力』のくだり聴きいっちゃう',
-                                    '丸い植え込み見ると、ガイモンさんが恋しい',
-                                    'ギンに振る舞われたの、チャーハンと間違えがち'][index]}" %>
-
+            <div class="relative mt-2" data-controller="character-counter" data-character-counter-countdown-value="true">
+                <%= f.text_area field, id: field,
+                    class: "input input-bordered border-2 border-sky-300 rounded-md w-72
+                            text-sm text-orange-500 font-bold h-[75px]
+                            placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
+                    placeholder: "例:#{['ゾロがまだ陽気',
+                                            '３巻まではSBSないから、すぐ読み終えちゃう',
+                                            'アニメのオープニング『富・名声・力』のくだり聴きいっちゃう',
+                                            '丸い植え込み見ると、ガイモンさんが恋しい',
+                                            'ギンに振る舞われたの、チャーハンと間違えがち'][index]}",
+                    data: { character_counter_target: "input" }, maxlength: 40 %>
+                <p class="absolute right-2 bottom-2 text-xs text-green-500">
+                    あと <strong data-character-counter-target="counter"></strong> 字まで
+                </p>
             </div>
         <% end %>
 
     <%= f.submit t("posts.#{params[:action]}"),
         class: "btn btn-sm text-white font-semibold rounded-lg mt-4
                 drop-shadow-lg hover:drop-shadow-none bg-[#0088D0] hover:bg-orange-500" %>
+    <br>
     <%= render 'shared/index_backbutton' %>
 
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 </div>
 
-<div class="pl-8">
+<div class="pl-8 mt-8">
     <%= render 'shared/index_backbutton' %>
     <%= render 'shared/toppage_backbutton' %>
 </div>

--- a/app/views/search_posts/search.html.erb
+++ b/app/views/search_posts/search.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 </div>
 
-<div class="pl-8">
+<div class="pl-8 mt-8">
     <%= render 'shared/index_backbutton' %>
     <%= render 'shared/toppage_backbutton' %>
 </div>

--- a/app/views/tops/_howto.html.erb
+++ b/app/views/tops/_howto.html.erb
@@ -1,4 +1,5 @@
-<button class="font-bold text-2xl whitespace-nowrap text-[#F50968] hover:text-[#5099ff] drop-shadow-lg hover:drop-shadow-none"
+<button class="btn font-bold text-lg drop-shadow-md hover:drop-shadow-md
+                bg-yellow-50 hover:bg-cyan-50 text-[#F50968] hover:text-[#5099ff]"
     onclick="howto.showModal()">遊び方</button>
 
 <dialog id="howto" class="modal">

--- a/app/views/tops/toppage.html.erb
+++ b/app/views/tops/toppage.html.erb
@@ -14,7 +14,7 @@
         <%= image_tag 'logo-clear.png', class: 'w-80 h-auto aspect-[1/1]' %>
     </div>
 
-    <div class="flex justify-center mb-4">
+    <div class="flex justify-center my-4">
         <%= render 'tops/howto' %>
     </div>
 

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 </div>
 
-<div class="pl-8">
+<div class="pl-8 mt-8">
     <%= render 'shared/index_backbutton' %>
     <%= render 'shared/toppage_backbutton' %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,6 @@
 ja:
   posts:
-    new: "投稿ぉ！"
+    new: "投稿ぉ"
+    create: "投稿ぉ！"
     edit: "更新っ"
+    update: "更新っ！"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.4",
+    "@stimulus-components/character-counter": "^5.0.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,6 +215,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.1.3.tgz#4db480347775aeecd4dde2405659eef74a458881"
   integrity sha512-ojNvnoZtPN0pYvVFtlO7dyEN9Oml1B6IDM+whGKVak69MMYW99lC2NOWXWeE3bmwEydbP/nn6ERcpfjHVjYQjA==
 
+"@stimulus-components/character-counter@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-components/character-counter/-/character-counter-5.0.0.tgz#9a1e9e88d2893212270bda7e254a5b80d0081b0f"
+  integrity sha512-oMXJ6B6qtV6FRmLa6riMNn/7Nym1m0RxN9q4Vv3KrVOlfXBZlHxAwGpCfC4+sIEKwTl08bWj1iDry97kdzF9nA==
+
 "@tailwindcss/container-queries@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz#9a759ce2cb8736a4c6a0cb93aeb740573a731974"


### PR DESCRIPTION
# 投稿機能#8：文字数カウンター実装 
該当issue：#251
**できるようになったこと**
- 投稿や投稿の編集の際、入力フォームにあと何文字入力できるかカウンターを表示
    - http://localhost:3000/posts/new （投稿画面）
    - http://localhost:3000/posts/:投稿ID/edit （投稿編集画面）
[![Image from Gyazo](https://i.gyazo.com/e216a6982c2a42ca328a7528353916eb.gif)](https://gyazo.com/e216a6982c2a42ca328a7528353916eb)
____
**実装**
Stimulus公式：[Character Counter](https://www.stimulus-components.com/docs/stimulus-character-counter)
- `app/javascript/controllers/application.js`
  - Character Counterを読み込み
  - デバック用のログを出力
- `app/views/posts/_form.html.erb`：入力フォームに文字数カウンターを適応
- `config/locales/views/ja.yml`
  - `create`と`update`の日本語を設定してなかったので追記
____
以下のファイルの変更は、今回の実装とは無関係
- **検索機能を修正**
  - `app/controllers/search_posts_controller.rb`：漢字でも検索できるように不要な記載を削除
- **CSSを修正**
  - `app/views/tops/toppage.html.erb`：遊び方モーダルの位置を調整
  - `app/views/tops/_howto.html.erb`：遊び方モーダルをボタンクラスを追加
  - `app/views/games/start.html.erb`：上部の隙間を削除、一覧へ戻るボタンの上部に隙間を用意
  - `app/views/posts/index.html.erb`：一覧へ戻るボタンの上部に隙間を用意
  - `app/views/users/posts/index.html.erb`：一覧へ戻るボタンの上部に隙間を用意
____
