### PR TITLE
Rspec#2：リクエストスペック作成（ `Games`コントローラー`start`アクションで、投稿データが正しく渡ってるかテスト） close #98

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,8 @@ FactoryBot.define do
         sequence(:email) { |n| "user_#{n}@example.com" }
         password { "password" }
         password_confirmation { "password" }
-        end
+        name { "ユーザー名" }
+        provider { "provider_name" }
+        uid { "unique_uid" }
+    end
 end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 
 RSpec.describe "Games", type: :request do
     describe "GET /games/start/:id" do
-    pending "add some examples (or delete) #{__FILE__}"
+        let!(:post) { create(:post) } # FactoryBotを使ってポストを作成
+
+        it "正しいポストデータを取得する" do
+            get start_game_path(post.id)
+            expect(response.status).to eq(200)
+            expect(response).to be_successful  # レスポンスが成功であることを確認
+            expect(response.body).to include(post.title)  # 投稿データのタイトルが含まれているか確認
+        end
     end
 end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Games", type: :request do
+    describe "GET /games/start/:id" do
+    pending "add some examples (or delete) #{__FILE__}"
+    end
+end


### PR DESCRIPTION
#  リクエストスペックを作成
## `Games`コントローラーの`start`アクションで、投稿データがゲーム画面に渡ってるかテスト
該当issue：#98
**できるようになったこと**
- 以下のコマンドでテストを実行できる
```bash
docker compose exec web bundle exec rspec
```
[![Image from Gyazo](https://i.gyazo.com/b9166b9a83a23233ad670b3b90e5c8c2.png)](https://gyazo.com/b9166b9a83a23233ad670b3b90e5c8c2)
-  またはbashに入って以下のコマンド
```bash
bundle exec rspec spec/requests/games_spec.rb
```
[![Image from Gyazo](https://i.gyazo.com/8d5c72d5da701ae12528da5c7a20965c.png)](https://gyazo.com/8d5c72d5da701ae12528da5c7a20965c)
____
**実装**
参考記事：[[Rails] Rspec基礎 factory_bot〜request spec](https://qiita.com/aaaasahi_17/items/70e1243da73314fd9a78#get%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88)
- **factorybotで生成する「ユーザーの情報」の不足分を追記**
  - `spec/factories/posts.rb`
- **リクエストスペックを作成**
  - `spec/requests/games_spec.rb`を生成、テストケース/テストコードを追記

**しなかったこと**
- コントローラースペックは、Rails公式で非推奨とのことで却下