### PR TITLE
Google Analytics 4を設定 close #256

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,16 @@
 
     <!-- 静的OGP（ゲーム画面のみ動的OGP） -->
     <%= display_meta_tags(default_meta_tags) %>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7M5YD1J9TK"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-7M5YD1J9TK');
+    </script>
   </head>
 
   <header>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,7 +4,7 @@
     <dr>
 
     <div class="relative" data-controller="character-counter" data-character-counter-countdown-value="true">
-        <%= f.text_area :title, id: "post_title",
+        <%= f.text_area :title, id: "post_title", autofocus: true,
             class: "input input-bordered border-2 border-sky-300 rounded-md w-72 h-16
                     text-sm text-orange-500 font-bold rows-2
                     placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
@@ -18,7 +18,7 @@
     <%= f.label :aruarus, "あるあるを５つ、入力してね！", class: "label text-[#0088D0] text-sm pb-0" %>
         <% [:aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five].each_with_index do |field, index| %>
             <div class="relative mt-2" data-controller="character-counter" data-character-counter-countdown-value="true">
-                <%= f.text_area field, id: field,
+                <%= f.text_area field, id: field, autofocus: true,
                     class: "input input-bordered border-2 border-sky-300 rounded-md w-72
                             text-sm text-orange-500 font-bold h-[75px]
                             placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",


### PR DESCRIPTION
# Google Analytics 4を設定　該当issue： #256

**できるようになったこと**
- https://aruaru-game.onrender.com にアクセスされた数値が確認できる
[![Image from Gyazo](https://i.gyazo.com/1c61e237ef6ee45ee083377438bc8217.png)](https://gyazo.com/1c61e237ef6ee45ee083377438bc8217)

____
**実装**
参考記事：[【Rails7】Google Analytics 4（GA4）を導入する](https://zenn.dev/yoiyoicho/articles/1fe05797a1bbc4)
- `app/views/layouts/application.html.erb`：Googleタグ を手動でインストールした
____
以下のファイルの変更はCSS調整やインデント修正など、今回の実装とは無関係の内容。
- 参考記事：[【Ruby on Rails】autofocus: trueを使って自動で焦点をあてる方法](https://qiita.com/nao0725/items/c8593880ee1c5526e693)
  - `app/views/posts/_form.html.erb`：投稿の入力フォームに、自動でフォーカスする設定を追記
