### PR TITLE
fix: ゲーム画面右側の謎の余白などのCSSを修正

### DIFF
--- a/app/uploaders/post_ogp_uploader.rb
+++ b/app/uploaders/post_ogp_uploader.rb
@@ -10,7 +10,7 @@ class PostOgpUploader < CarrierWave::Uploader::Base
       "#{mounted_as}_production:post_ID:#{model.id}"
     else
       # 保存できてるかテスト時用のフォルダ名
-      "#{mounted_as}_development:post_ID:#{model.id}"
+      "OGP/#{mounted_as}_development:post_ID:#{model.id}"
     end
   end
 end

--- a/app/views/games/start.html.erb
+++ b/app/views/games/start.html.erb
@@ -2,7 +2,7 @@
     <div class='items-center bg-custom-yellow'>
         <div class='ml-4'>
             <div class="text-sky-800 text-sm"><%= "#{@post.user.name}さんが思う" %></div>
-            <div class="text-2xl text-sky-600 font-bold mb-0"><%= @post.title %></div>
+            <div class="text-2xl text-sky-600 font-bold mb-0 text-balance"><%= @post.title %></div>
 
             <div class='flex justify-end gap-2 pr-4'>
                 <div class="text-sky-400 text-sm">界隈あるある</div>

--- a/app/views/games/start.html.erb
+++ b/app/views/games/start.html.erb
@@ -1,15 +1,16 @@
 <div class='flex justify-center'>
-    <div class='items-center'>
+    <div class='items-center bg-custom-yellow'>
+        <div class='ml-4'>
+            <div class="text-sky-800 text-sm"><%= "#{@post.user.name}さんが思う" %></div>
+            <div class="text-2xl text-sky-600 font-bold mb-0"><%= @post.title %></div>
 
-        <div class="text-sky-800 text-sm"><%= "#{@post.user.name}さんが思う" %></div>
-        <div class="text-2xl text-sky-600 font-bold mb-0"><%= @post.title %></div>
-
-        <div class='flex justify-end gap-2 pr-2'>
-            <div class="text-sky-400 text-sm">界隈あるある</div>
-            <%= render 'shared/xshare_button', post: @post %>
-        </div>
-        <div class='mb-2'>
-            <%= render 'tags/tags_list', post: @post %>
+            <div class='flex justify-end gap-2 pr-4'>
+                <div class="text-sky-400 text-sm">界隈あるある</div>
+                <%= render 'shared/xshare_button', post: @post %>
+            </div>
+            <div class='mb-2'>
+                <%= render 'tags/tags_list', post: @post %>
+            </div>
         </div>
 
         <!-- ゲーム画面に必要な記述 -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
   <body class="bg-custom-yellow">
     <%= render 'shared/header' %>
 
-    <div class="py-[68px]">
+    <div class="pt-[58px] pb-[70px]">
       <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>
@@ -42,6 +42,5 @@
       <%= render 'games/clear_modal' %>
     <% end %>
   </body>
-
 
 </html>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -8,7 +8,7 @@
 
             <!-- 自作投稿一覧以外に表示する場合は、カレントユーザー名を表示 -->
             <% if request.path != myindex_posts_path %>
-                <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんの思う</ul>
+                <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんが思う</ul>
             <% end %>
 
             <div id="post-id-<%= post.id %>">
@@ -40,7 +40,7 @@
             class: "block post-box bg-green-50 border-2 border-green-100 rounded-lg shadow-md
                     hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
             <div id="post-id-<%= post.id %>">
-            <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんの思う</ul>
+            <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんが思う</ul>
                 <div class="post-box-title font-bold p-2 pb-0 text-lime-800 drop-shadow-md group-hover:drop-shadow-none">
                     <%= post.title %></div>
                 <div class="text-lime-600 p-2 text-xs">あるあるで遊ぶ</div>

--- a/app/views/search_posts/search.html.erb
+++ b/app/views/search_posts/search.html.erb
@@ -5,7 +5,7 @@
     <div class="text-md text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
 
     <% if @posts.present? %>
-        <div class="flex flex-wrap justify-center gap-4">
+        <div class="flex flex-wrap justify-center gap-1">
             <%= render @posts %>
         </div>
     <% else %>

--- a/app/views/shared/header/_search_form.html.erb
+++ b/app/views/shared/header/_search_form.html.erb
@@ -5,7 +5,7 @@
                 data-autocomplete-url-value="<%= autocomplete_search_posts_path %>"
                 role="combobox">
                 <%= f.search_field :title_cont, data: { autocomplete_target: 'input' },
-                    class: "border-pink-300 shadow-md rounded-md w-40 h-8 pl-2 p-0 block
+                    class: "border-pink-300 shadow-md rounded-md w-36 h-8 pl-2 p-0 block
                             text-md text-orange-500 font-bold
                             placeholder:font-normal placeholder:text-gray-400 placeholder:text-xs",
                             placeholder: "どの界隈で遊ぶ？" %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -5,7 +5,7 @@
     <div class="text-md text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
 
     <% if @posts.present? %>
-        <div class="flex flex-wrap justify-center gap-4">
+        <div class="flex flex-wrap justify-center gap-1">
             <%= render @posts %>
         </div>
     <% else %>

--- a/app/views/tops/toppage.html.erb
+++ b/app/views/tops/toppage.html.erb
@@ -10,8 +10,8 @@
 
 <body class="text-center">
 
-    <div class="flex justify-center">
-        <%= image_tag 'logo-bg-custom-yellow.png', class: 'w-72 h-72 aspect-[1/1]' %>
+    <div class="flex justify-center mt-4">
+        <%= image_tag 'logo-bg-custom-yellow.png', class: 'w-64 h-64 aspect-[1/1]' %>
     </div>
 
     <div class="flex justify-center mb-4">


### PR DESCRIPTION
# fix: ゲーム画面右側の謎の余白などのCSSを修正
**変更前**
- スマホだとゲーム画面の左端が見切れており、スマホ機種によっては右端に謎の余白があった
  - https://aruaru-games.com/games/:投稿ID/start
[![Image from Gyazo](https://i.gyazo.com/23996f8fe8930d4f29e620d7b1fdb3f2.png)](https://gyazo.com/23996f8fe8930d4f29e620d7b1fdb3f2)
**できるようになったこと**
**修正後**
  - https://aruaru-games.com/games/:投稿ID/start
  [![Image from Gyazo](https://i.gyazo.com/7b95ea6df968bd061b4ee61eb9cfe6ab.png)](https://gyazo.com/7b95ea6df968bd061b4ee61eb9cfe6ab)
_____
**修正方法**
根本的な解消はできません
テキストを右に寄せて、背景色を追加し力づくで修正した感じです
レスポンシブ対応に、改めて修正できたらと思います