### PR TITLE
fix: 未ログイン状態でログイン必須ページに遷移した際の処理 close #272

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,12 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     posts_path
   end
+
+  # 未ログイン状態でログイン必須ページにアクセスした際の処理
+  def authenticate_user!
+    unless user_signed_in?
+        flash[:alert] = I18n.t('devise.failure.unauthenticated')
+        redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,9 +21,8 @@ class ApplicationController < ActionController::Base
 
   # 未ログイン状態でログイン必須ページにアクセスした際の処理
   def authenticate_user!
-    unless user_signed_in?
-        flash[:alert] = I18n.t('devise.failure.unauthenticated')
-        redirect_to root_path
-    end
+    return if user_signed_in?
+    flash[:alert] = I18n.t("devise.failure.unauthenticated")
+    redirect_to root_path
   end
 end


### PR DESCRIPTION
# fix: 未ログイン状態でログイン必須ページに遷移した際の処理
該当issue：#272

**変更前**
未ログイン状態で、ログイン必須ページ（`myindex_path`）にアクセスすると`root_path`に遷移しない
  - https://aruaru-games.com/games/:投稿ID/start → https://aruaru-games.com/posts/myindex.投稿ID
[![Image from Gyazo](https://i.gyazo.com/40964854028a6dcb7c25d5b50dd518d9.gif)](https://gyazo.com/40964854028a6dcb7c25d5b50dd518d9)

**変更後**
未ログイン状態で、ログイン必須ページ（`myindex_path`）にアクセスすると`root_path`に遷移する！
  - https://aruaru-games.com/games/:投稿ID/start → https://aruaru-games.com
[![Image from Gyazo](https://i.gyazo.com/cd0756bb06d00fbaa2e280cf307773a4.gif)](https://gyazo.com/cd0756bb06d00fbaa2e280cf307773a4)
____
**実装**
- `app/controllers/application_controller.rb`
  - 未ログイン状態でログイン必須ページに遷移した際の処理を追記
    - `config/locales/devise.ja.yml`のメッセージを表示
    - `root_path`にリダイレクト
