### PR TITLE
fix: ユーザー名変更画面への遷移。　再修正：未ログイン状態でログイン必須ページに遷移した際の処理 close #275

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
   end
 
   # 未ログイン状態でログイン必須ページにアクセスした際の処理
-  def authenticate_user!
+  def custom_authenticate_user!
     return if user_signed_in?
     flash[:alert] = I18n.t("devise.failure.unauthenticated")
     redirect_to root_path

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
-    before_action :authenticate_user!, only: %i[myindex new edit update create]
+    # ApplicationControllerのメソッドを使う
+    before_action :custom_authenticate_user!, only: %i[myindex new edit update create]
 
     def index
         @q = Post.ransack(params[:q])

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+  # Deviseのデフォルトの`authenticate_user!`を使用
+  prepend_before_action :authenticate_user!, only: [ :edit, :update ]
+
   protected
 
   def update_resource(resource, params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # OmniAuth：認証成功時の処理
   devise_for :users, controllers: {
     omniauth_callbacks: "users/omniauth_callbacks",
-    # sessions: "users/sessions",
+    sessions: "users/sessions", # カスタムコントローラーを使用
     registrations: "users/registrations" }
 
   devise_scope :user do


### PR DESCRIPTION
# fix: ユーザー名変更画面への遷移
# 再修正：未ログイン状態でログイン必須ページに遷移した際の処理

該当issue：#274
**できるようになったこと**
- ログイン状態で、ユーザー名の変更画面へ遷移してユーザー名を変更できる
  - http://localhost:4000/users/edit
  - 以前実装はできてたが、今回ログイン認証を修正した際にアクセスできなくなってしまったのを修正
  -  deviseデフォルトの`authenticate_user!`メソッドをカスタムして使用（`custom_authenticate_user!`）

**再修正**
- 未ログイン状態で、ログイン必須ページ（`myindex_path`）にアクセスすると`root_path`に遷移しなかったのを修正
  -  deviseデフォルトの`authenticate_user!`メソッドを使用
  - https://aruaru-games.com/games/:投稿ID/start → https://aruaru-games.com
[![Image from Gyazo](https://i.gyazo.com/cd0756bb06d00fbaa2e280cf307773a4.gif)](https://gyazo.com/cd0756bb06d00fbaa2e280cf307773a4)
____
**実装**
前回の修正（プルリク#95 https://github.com/pakira-56A/SAMPLE/pull/95/commits/39f5c231d5dbdff421509219a5b1b3132b0eb25e ）で
 deviseデフォルトの`authenticate_user!`メソッドを使って
「未ログイン状態で、ログイン必須ページ（`myindex_path`）にアクセスすると`root_path`に遷移しなかったのを修正」したが
今回の「ログイン状態で、ユーザー名の変更画面へ遷移してユーザー名を変更できる」を修正する際には`authenticate_user!`メソッドが競合してしまったので
deviseデフォルトの`authenticate_user!`メソッドをカスタム（`custom_authenticate_user!`）して修正した


- **[deviseデフォルトの`authenticate_user!`メソッドを使用してユーザー名変更を行う](https://github.com/pakira-56A/SAMPLE/commit/afcd48905b564d39d156d5215d73b9b32bbc2880)**
  - `app/controllers/users/registrations_controller.rb`
    - `authenticate_user!`メソッドでユーザー情報の`edit` `update`をアクセス制御
- **[`authenticate_user!`メソッドをカスタムして使用](https://github.com/pakira-56A/SAMPLE/commit/e5debf8b8ad3f0bd548ef200b2c16c9812adc015)**
  - `app/controllers/application_controller.rb`
    - 未ログイン状態でログイン必須ページにアクセスした際の処理名を`custom_authenticate_user!`に変更（カスタム）
    - `app/controllers/posts_controller.rb`：`custom_authenticate_user!`でアクセス制限を設定
    - `config/routes.rb`：`custom_authenticate_user!`をルーティング
    - `lib/custom_authentication_failure.rb`：deviseで認証失敗したさいの遷移先やレスポンスを設定