### PR TITLE
add: `遊んだみんなの感想をXで見る？👀`ボタンを設置

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,16 +1,16 @@
 module ApplicationHelper
   def default_meta_tags
     {
-      site: "界隈探求ゲーム",
-      title: "あるある神経衰弱",
+      site: "あるある神経衰弱：界隈探求ゲーム",
+      title: "あるある神経衰弱：界隈探求ゲーム",
       reverse: true,
       charset: "utf-8",
       description: "あらゆる界隈のあるあるを、AIで生成したり、みんなで投稿し遊ぶゲームです！",
       canonical: request.original_url,
       separator: "|",
       og: {
-        site_name: "界隈探求ゲーム",
-        title: "あるある神経衰弱",
+          site_name: "あるある神経衰弱：界隈探求ゲーム",
+          title: "あるある神経衰弱：界隈探求ゲーム",
         description: "あらゆる界隈のあるあるを、AIで生成したり、みんなで投稿し遊ぶゲームです！",
         type: "website",
         url: request.original_url,

--- a/app/views/games/_clear_modal.html.erb
+++ b/app/views/games/_clear_modal.html.erb
@@ -23,6 +23,12 @@
                     <% end %>
                 </div>
 
+                </br>
+                <div class="pb-4">
+                    <%= render "shared/xreview_button" %>
+                </div>
+            </div>
+
             <button class="close-button absolute top-3 right-3 text-gray-400 bg-transparent hover:bg-yellow-100 hover:text-red-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center">
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
   <body class="bg-custom-yellow">
     <%= render 'shared/header' %>
 
-    <div class="pt-[58px] pb-[70px]">
+    <div class="pt-[56px] pb-[70px]">
       <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,14 +1,14 @@
 <%= form_with(model: @post, class: "space-y-2") do |f| %>
-    <%= f.label :title, "界隈名", class: "label text-[#0088D0] text-xs pb-0" %>
+    <%= f.label :title, "界隈名（もう誰かが投稿した界隈名も大歓迎 🥳 ）", class: "label text-[#0088D0] text-xs pb-0" %>
 
     <div class="relative" data-controller="character-counter" data-character-counter-countdown-value="true">
         <%= f.text_area :title, id: "post_title", autofocus: true,
             class: "input input-bordered border-2 border-sky-300 rounded-md w-72 h-20
-                    text-sm text-orange-500 font-bold placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
-            placeholder: "例:ONEPIECEイーストブルー編",
+                    text-sm text-orange-500 font-bold placeholder:font-light placeholder:text-[#C7C7C7]",
+            placeholder: "例：ONEPIECEイーストブルー編",
             data: { character_counter_target: "input" }, maxlength: 40 %>
         <div class="absolute right-2 bottom-2 top-12 flex items-center text-xs">
-            <p class="text-orange-500">のあるある。</p>
+            <p class="text-orange-500 font-bold">のあるある。</p>
             <p class="text-green-500">
                 あと <strong data-character-counter-target="counter"></strong> 字まで</p>
         </div>
@@ -20,8 +20,8 @@
                 <%= f.text_area field, id: field, autofocus: true,
                     class: "input input-bordered border-2 border-sky-300 rounded-md w-72 h-20
                             text-sm text-orange-500 font-bold
-                            placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
-                    placeholder: "例:#{['ゾロがまだ陽気',
+                            placeholder:font-light placeholder:text-[#C7C7C7]",
+                    placeholder: "例：#{['ゾロがまだ陽気',
                                             '３巻まではSBSないから、すぐ読み終えちゃう',
                                             'アニメのオープニング『富・名声・力』のくだり聴きいっちゃう',
                                             '丸い植え込み見ると、ガイモンさんが恋しい',
@@ -38,7 +38,7 @@
     <!-- value:@tagsでタグの配列を取得 -->
     <%= f.text_field :tag, placeholder: "漫画 アニメ ジャンプ",
         class: "border-2 border-sky-300 rounded-md w-72
-            text-sm text-orange-500 font-bold placeholder:font-light placeholder:text-[#C7C7C7] placeholder:text-xs",
+            text-sm text-orange-500 font-bold placeholder:font-light placeholder:text-[#C7C7C7]",
         value: @tags %>
     <br>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -11,7 +11,7 @@
                 <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんが思う</ul>
             <% end %>
 
-            <div id="post-id-<%= post.id %>">
+            <div id="post-id-<%= post.id %>" class="text-left">
                 <div class="post-box-title font-bold p-2 pb-0 text-cyan-800 drop-shadow-md group-hover:drop-shadow-none">
                     <%= post.title %></div>
                 <div class="text-cyan-600 p-2 text-xs">あるあるで遊ぶ</div>
@@ -39,7 +39,7 @@
         <%= link_to start_game_path(post),
             class: "block post-box bg-green-50 border-2 border-green-100 rounded-lg shadow-md
                     hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
-            <div id="post-id-<%= post.id %>">
+            <div id="post-id-<%= post.id %>" class="text-left">
             <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんが思う</ul>
                 <div class="post-box-title font-bold p-2 pb-0 text-lime-800 drop-shadow-md group-hover:drop-shadow-none">
                     <%= post.title %></div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -8,7 +8,7 @@
 
             <!-- 自作投稿一覧以外に表示する場合は、カレントユーザー名を表示 -->
             <% if request.path != myindex_posts_path %>
-                <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんが思う</ul>
+                <ul class="text-left list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんが思う</ul>
             <% end %>
 
             <div id="post-id-<%= post.id %>" class="text-left">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,11 @@
         <div class="text-3xl font-bold text-green-600">みんなが思う</div>
         <div class="text-lg font-bold text-lime-500 ml-2"><%= "界隈あるある一覧" %></div>
     </div>
-    <div class="text-md text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
+    <div class="text-md text-cyan-500 pb-2 text-center"><%= "ゆかりがない界隈でも遊んでみよう！" %>
+        <div class="pt-2 pb-4">
+            <%= render "shared/xreview_button" %>
+        </div>
+    </div>
 
     <% if @posts.present? %>
         <div class="flex flex-wrap justify-center gap-1">

--- a/app/views/search_posts/search.html.erb
+++ b/app/views/search_posts/search.html.erb
@@ -2,7 +2,11 @@
     <div class="flex items-center mb-2">
         <div class="text-xl font-bold text-fuchsia-400"><%= "見つけた界隈あるある一覧" %></div>
     </div>
-    <div class="text-md text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
+    <div class="text-md text-cyan-500 pb-2 text-center"><%= "ゆかりがない界隈でも遊んでみよう！" %>
+        <div class="pt-2 pb-4">
+            <%= render "shared/xreview_button" %>
+        </div>
+    </div>
 
     <% if @posts.present? %>
         <div class="flex flex-wrap justify-center gap-1">

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,4 +1,4 @@
-<div class="flex inset-0 justify-center items-center my-2">
+<div class="flex inset-0 justify-center items-center pt-2 my-2">
 
     <% if notice.present? %>
         <p class="py-2 px-3 bg-green-50 text-green-500 font-medium rounded-lg inline-block" id="notice">

--- a/app/views/shared/_xreview_button.html.erb
+++ b/app/views/shared/_xreview_button.html.erb
@@ -1,0 +1,8 @@
+<div class="twitter flex justify-center">
+<%= link_to "https://x.com/hashtag/%E3%81%82%E3%82%8B%E3%81%82%E3%82%8B%E7%A5%9E%E7%B5%8C%E8%A1%B0%E5%BC%B1?src=hashtag_click&f=live",
+    target: '_blank',
+    class: "rounded-lg p-1 px-2
+            text-sm text-[#808080] bg-cyan-50 border-2 border-cyan-200 drop-shadow-md
+            hover:text-[#FF7611] hover:bg-white hover:border-orange-500 hover:drop-shadow-none" do %>
+    遊んだみんなの感想を<%= image_tag 'xshare.svg', class: "inline-flex items-center h-6 w-6", id: 'image-xshare' %>で見る？👀
+<% end %>

--- a/app/views/shared/_xshare_button.html.erb
+++ b/app/views/shared/_xshare_button.html.erb
@@ -1,5 +1,5 @@
 <div class="twitter">
-    <%= link_to "https://twitter.com/intent/tweet?url=#{request.base_url}/games/#{post.id}/start&text=#{ERB::Util.url_encode("\n#{post.user.name}さんが思う\n##{post.title.gsub(/[^\p{Alnum}\s]/u, '')} あるあるをシェア！\n#あるある神経衰弱\n")}",
+    <%= link_to "https://twitter.com/intent/tweet?url=#{request.base_url}/games/#{post.id}/start&text=#{ERB::Util.url_encode("\n\n\n#{post.user.name}さんが思う\n##{post.title.gsub(/[^\p{Alnum}\s]/u, '')} あるあるをシェア！\n#あるある神経衰弱\n")}",
         target: '_blank',
         data: { toggle: "tooltip", placement: "bottom" },
         title: "Xでシェア" do %>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -4,10 +4,15 @@
 </div>
 
 <div class="flex flex-col items-center">
-    <div class="flex items-center mb-4">
+    <div class="flex items-center">
         <div class="text-3xl font-bold text-sky-600"><%= "#{current_user.name}" %></div>
-        <div class="text-lg font-bold text-sky-500 ml-2"><%= "作・界隈あるある一覧" %></div>
+        <div class="text-lg font-bold text-sky-500 ml-2"><%= "作" %></div>
     </div>
+    <div class="text-lg font-bold text-sky-500 ml-2 mb-2"><%= "界隈あるある一覧" %></div>
+    <div class="pb-4">
+        <%= render "shared/xreview_button" %>
+    </div>
+</div>
 
     <% if @posts.present? %>
         <div class="flex flex-wrap justify-center gap-1">


### PR DESCRIPTION
#  `遊んだみんなの感想をXで見る？👀`ボタンを設置
該当issue：#280
**できるようになったこと**
- `遊んだみんなの感想をXで見る？👀`ボタンで、Xの [#あるある神経衰弱](https://x.com/search?q=%23%E3%81%82%E3%82%8B%E3%81%82%E3%82%8B%E7%A5%9E%E7%B5%8C%E8%A1%B0%E5%BC%B1&src=recent_search_click&f=live)へ遷移
    - http://aruaru-games.com/games/投稿ID/start （ゲームクリア後のモーダル）
    - http://aruaru-games.com/posts （他者の投稿一覧）
    - http://aruaru-games.com/posts/myindex （自作あるある一覧）
    - http://aruaru-games.com/search_posts/search? （検索結果一覧）
[![Image from Gyazo](https://i.gyazo.com/604df2a8fd5ec4cbc9d99c9567421288.gif)](https://gyazo.com/604df2a8fd5ec4cbc9d99c9567421288)
____
- **[fix: CSS微調整](https://github.com/pakira-56A/aruaru-game/pull/279/commits/dfbed9ed76e8a9ae69d6300755cf853cce4d4cf4)**
  - `app/helpers/application_helper.rb`：OGPで表示されるサイト名を`あるある神経衰弱：界隈探求ゲーム`に変更
  - `app/views/layouts/application.html.erb`：微調整
  - `app/views/posts/_form.html.erb`：投稿フォームに「界隈名の重複OK」を記載
  - `app/views/shared/_flash_message.html.erb`
 - **[fix: Xシェアした際のポストに改行をを追加](https://github.com/pakira-56A/aruaru-game/pull/279/commits/a65d38dbd6021e9658501fc5eb29084f133c0989)**
   - `app/views/shared/_xshare_button.html.erb`
 - **[add: `遊んだみんなの感想をXで見る？👀`ボタンを生成](https://github.com/pakira-56A/aruaru-game/pull/279/commits/da8d0edc4fcbb89bfa1b6ed3a2b7c6f8a5f95363)**
   - `app/views/shared/_xreview_button.html.erb`
 - **[fix: `遊んだみんなの感想をXで見る？👀`ボタンを呼び出し](https://github.com/pakira-56A/aruaru-game/pull/279/commits/13cd93d86dcde5f3a732e46a857e56ca23607db8)**
   - `app/views/games/_clear_modal.html.erb`
   - `app/views/posts/index.html.erb`
   - `app/views/search_posts/search.html.erb`
   - `app/views/users/posts/index.html.erb`
  - **[fix: 投稿boxのテキストをを左寄せに](https://github.com/pakira-56A/aruaru-game/pull/279/commits/1c8ea979c689e67ff37c01a7fe9cc5d7cec55da0)**
    - `app/views/posts/_post.html.erb`