### PR TITLE
fix:  投稿画面に`他の投稿と同じ界隈名でもOK`と追記

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: @post, class: "space-y-2") do |f| %>
-    <%= f.label :title, "界隈名（もう誰かが投稿した界隈名も大歓迎 🥳 ）", class: "label text-[#0088D0] text-xs pb-0" %>
+    <%= f.label :title, "界隈名（他の投稿と同じ界隈名でもOK 🥳 ）", class: "label text-[#0088D0] text-xs pb-0" %>
 
     <div class="relative" data-controller="character-counter" data-character-counter-countdown-value="true">
         <%= f.text_area :title, id: "post_title", autofocus: true,

--- a/app/views/shared/_xreview_button.html.erb
+++ b/app/views/shared/_xreview_button.html.erb
@@ -1,5 +1,5 @@
 <div class="twitter flex justify-center">
-<%= link_to "https://x.com/hashtag/%E3%81%82%E3%82%8B%E3%81%82%E3%82%8B%E7%A5%9E%E7%B5%8C%E8%A1%B0%E5%BC%B1?src=hashtag_click&f=live",
+<%= link_to "https://x.com/hashtag/あるある神経衰弱?src=hashtag_click&f=live",
     target: '_blank',
     class: "rounded-lg p-1 px-2
             text-sm text-[#808080] bg-cyan-50 border-2 border-cyan-200 drop-shadow-md


### PR DESCRIPTION
# fix:  投稿画面：`他の投稿と同じ界隈名でもOK`と追記

**できるようになったこと**
- 投稿時に、既に投稿された界隈名と同じ界隈名を投稿してもよいと分かりやすくした
  - https://aruaru-games.com/posts/new
[![Image from Gyazo](https://i.gyazo.com/a698646967c8b86a3f9a2500e6597e1b.png)](https://gyazo.com/a698646967c8b86a3f9a2500e6597e1b)
- `遊んだみんなの感想をXで見る？👀`ボタンの遷移先（[#あるある神経衰弱](https://x.com/search?q=%23%E3%81%82%E3%82%8B%E3%81%82%E3%82%8B%E7%A5%9E%E7%B5%8C%E8%A1%B0%E5%BC%B1&src=recent_search_click&f=live)）わかりやすいURLに変更
[![Image from Gyazo](https://i.gyazo.com/27534db4d77ba9e9aadafe240d2b42da.gif)](https://gyazo.com/27534db4d77ba9e9aadafe240d2b42da)
____
**実装**
- `app/views/posts/_form.html.erb`：投稿画面：`他の投稿と同じ界隈名でもOK`と追記
- `app/views/shared/_xreview_button.html.erb`
  `遊んだみんなの感想をXで見る？👀`ボタンの遷移先を、わかりやすいURLに変更
  ```rb
  - <%= link_to "https://x.com/hashtag/%E3%81%82%E3%82%8B%E3%81%82%E3%82%8B%E7%A5%9E%E7%B5%8C%E8%A1%B0%E5%BC%B1?src=hashtag_click&f=live",
  + <%= link_to "https://x.com/hashtag/あるある神経衰弱?src=hashtag_click&f=live",
  ```