### PR TITLE
fix: Xシェア時に投稿タイトルにスペースが含まれる場合はハッシュタグ化

### DIFF
--- a/app/views/shared/_xshare_button.html.erb
+++ b/app/views/shared/_xshare_button.html.erb
@@ -1,5 +1,5 @@
 <div class="twitter">
-    <%= link_to "https://twitter.com/intent/tweet?url=#{request.base_url}/games/#{post.id}/start&text=#{ERB::Util.url_encode("\n\n\n#{post.user.name}さんが思う\n##{post.title.gsub(/[^\p{Alnum}\s]/u, '')} あるあるをシェア！\n#あるある神経衰弱\n")}",
+    <%= link_to "https://twitter.com/intent/tweet?url=#{request.base_url}/games/#{post.id}/start&text=#{ERB::Util.url_encode("\n\n\n#{post.user.name}さんが思う\n##{post.title.gsub(/[^\p{Alnum}　\s]/u, '').gsub(/([ 　]+)/, ' #')} あるあるをシェア！\n#あるある神経衰弱\n")}",
         target: '_blank',
         data: { toggle: "tooltip", placement: "bottom" },
         title: "Xでシェア" do %>


### PR DESCRIPTION
# fix: Xシェア時に投稿タイトルにスペースが含まれる場合はハッシュタグ化
**変更前**
- 投稿タイトルにスペースがある場合、ハッシュタグが崩れたXシェアになってしまう
[![Image from Gyazo](https://i.gyazo.com/39a9507a441ac47d85c3ac19c857a876.png)](https://gyazo.com/39a9507a441ac47d85c3ac19c857a876)

**変更後**
- Xシェア時に投稿タイトルにスペースが含まれる場合はハッシュタグ化される
[![Image from Gyazo](https://i.gyazo.com/81dd0c43d61b9a50e6888c51b352de6c.gif)](https://gyazo.com/81dd0c43d61b9a50e6888c51b352de6c)
スクショ
____
**実装**
- `app/views/shared/_xshare_button.html.erb`
  - Xシェア時に投稿タイトルにスペースが含まれる場合はハッシュタグ化される指示を追記
  - 投稿タイトルにスペースが半角でも、全角でも対応
```rb
- ...#{post.title.gsub(/[^\p{Alnum}\s]/u, '')} 
+ ...#{post.title.gsub(/[^\p{Alnum}　\s]/u, '').gsub(/([ 　]+)/, ' #')} 
```
