### PR TITLE
fix: ビューのテンプレを増やして整理（投稿がない場合とGoogleログインボタン） close "284

### DIFF
--- a/app/views/google_login_api/callback.html.erb
+++ b/app/views/google_login_api/callback.html.erb
@@ -1,2 +1,0 @@
-<h1>GoogleLoginApi#callback</h1>
-<p>Find me in app/views/google_login_api/callback.html.erb</p>

--- a/app/views/posts/_no_posts.html.erb
+++ b/app/views/posts/_no_posts.html.erb
@@ -1,9 +1,0 @@
-<div class="text-center mb-3 text-gray-500">まだないよ！投稿しよう！</div>
-<div class="menu-list2" >
-    <%= link_to image_tag('footer/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
-        new_post_path,
-        class: "btn btn-md items-center no-underline rounded-lg w-hull px-2 mb-2 p-0 gap-2
-                font-bold text-nowrap text-[#0088D0] hover:text-[#00c5ff]
-                bg-white hover:bg-white border-2 hover:border-orange-400
-                drop-shadow-md hover:drop-shadow-none" %>
-</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,13 +9,6 @@
         </div>
     </div>
 
-    <% if @posts.present? %>
-        <div class="flex flex-wrap justify-center gap-1">
-            <%= render @posts %>
-        </div>
-    <% else %>
-        <div class="my-10">
-            <%= render 'no_posts' %>
-        </div>
-    <% end %>
+    <%= render 'shared/posts/existence_or_empty', post: @posts %>
+
 </div>

--- a/app/views/search_posts/autocomplete.html.erb
+++ b/app/views/search_posts/autocomplete.html.erb
@@ -10,7 +10,8 @@
         <% end %>
     <% else %>
         <li class="autocomplete-item w-56 flex flex-col items-start gap-x-3 py-2 px-3 bg-white rounded-md">
-            <%= render 'posts/no_posts' %>
+            <%= render "shared/posts/empty_posts_text" %>
+            <%= render "shared/posts/new_posts_button" %>
         </li>
     <% end %>
 </ul>

--- a/app/views/search_posts/search.html.erb
+++ b/app/views/search_posts/search.html.erb
@@ -8,13 +8,6 @@
         </div>
     </div>
 
-    <% if @posts.present? %>
-        <div class="flex flex-wrap justify-center gap-1">
-            <%= render @posts %>
-        </div>
-    <% else %>
-        <div class="my-10">
-            <%= render 'posts/no_posts' %>
-        </div>
-    <% end %>
+    <%= render 'shared/posts/existence_or_empty', post: @posts %>
+
 </div>

--- a/app/views/shared/_googleloginbutton.html.erb
+++ b/app/views/shared/_googleloginbutton.html.erb
@@ -1,0 +1,6 @@
+<%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false },
+    class: "btn btn-sm gap-1 font-semibold rounded-full bg-white hover:border-orange-500 hover:bg-white" do %>
+    <img width="20" height="20" alt="Googleログイン" class="inline-block"
+        src="https://img.icons8.com/external-those-icons-flat-those-icons/24/external-Google-logos-and-brands-those-icons-flat-those-icons.png"/>
+    <span class="text-xs text-gray-400 font-light">ログイン</span>
+<% end %>

--- a/app/views/shared/_xreview_button.html.erb
+++ b/app/views/shared/_xreview_button.html.erb
@@ -2,7 +2,7 @@
 <%= link_to "https://x.com/hashtag/あるある神経衰弱?src=hashtag_click&f=live",
     target: '_blank',
     class: "rounded-lg p-1 px-2
-            text-sm text-[#808080] bg-cyan-50 border-2 border-cyan-200 drop-shadow-md
+            text-sm text-[#808080] bg-orange-100 border-2 border-white drop-shadow-md
             hover:text-[#FF7611] hover:bg-white hover:border-orange-500 hover:drop-shadow-none" do %>
     遊んだみんなの感想を<%= image_tag 'xshare.svg', class: "inline-flex items-center h-6 w-6", id: 'image-xshare' %>で見る？👀
 <% end %>

--- a/app/views/shared/header/_googleloginbutton_or_logo.html.erb
+++ b/app/views/shared/header/_googleloginbutton_or_logo.html.erb
@@ -8,12 +8,7 @@
 <% else %>
 
     <div class="mt-3">
-    <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false },
-        class: "btn btn-sm gap-1 font-semibold rounded-full bg-white hover:border-orange-500 hover:bg-white" do %>
-        <img width="20" height="20" alt="Googleログイン" class="inline-block"
-            src="https://img.icons8.com/external-those-icons-flat-those-icons/24/external-Google-logos-and-brands-those-icons-flat-those-icons.png"/>
-        <span class="text-xs text-gray-400 font-light">ログイン</span>
-    <% end %>
+        <%= render 'shared/googleloginbutton' %>
     </div>
 
 <% end %>

--- a/app/views/shared/posts/_empty_posts_text.html.erb
+++ b/app/views/shared/posts/_empty_posts_text.html.erb
@@ -1,0 +1,1 @@
+<div class="text-center mb-3 text-gray-500">まだないよ！投稿しよう！</div>

--- a/app/views/shared/posts/_existence_or_empty.html.erb
+++ b/app/views/shared/posts/_existence_or_empty.html.erb
@@ -1,0 +1,14 @@
+<% if @posts.present? %>
+
+    <div class="flex flex-wrap justify-center gap-1">
+        <%= render @posts %>
+    </div>
+
+<% else %>
+
+    <div class="my-10">
+        <%= render "shared/posts/empty_posts_text" %>
+        <%= render "shared/posts/new_posts_button" %>
+    </div>
+
+<% end %>

--- a/app/views/shared/posts/_index_button.html.erb
+++ b/app/views/shared/posts/_index_button.html.erb
@@ -1,0 +1,8 @@
+<div class="menu-list1" >
+<%= link_to image_tag('footer/menu/menu-1.svg', width: '25', height: '25', id: 'image-menu1') + 'みんなの投稿で遊ぶ',
+    posts_path,
+    class: "btn btn-md items-center no-underline rounded-lg w-hull px-2 mb-2 p-0 gap-2
+            font-bold text-nowrap text-[#019c8f] hover:text-[#00e297]
+            bg-white hover:bg-white border-2 hover:border-orange-400
+            drop-shadow-md hover:drop-shadow-none" %>
+</div>

--- a/app/views/shared/posts/_new_posts_button.html.erb
+++ b/app/views/shared/posts/_new_posts_button.html.erb
@@ -1,0 +1,8 @@
+<div class="menu-list2" >
+    <%= link_to image_tag('footer/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
+        new_post_path,
+        class: "btn btn-md items-center no-underline rounded-lg w-hull px-2 mb-2 p-0 gap-2
+                font-bold text-nowrap text-[#0088D0] hover:text-[#00c5ff]
+                bg-white hover:bg-white border-2 hover:border-orange-400
+                drop-shadow-md hover:drop-shadow-none" %>
+</div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -4,13 +4,7 @@
     </div>
     <div class="text-md text-cyan-500 pb-4"><%= "ゆかりがない界隈でも遊んでみよう！" %></div>
 
-    <% if @posts.present? %>
-        <div class="flex flex-wrap justify-center gap-1">
-            <%= render @posts %>
-        </div>
-    <% else %>
-        <div class="my-10">
-            <%= render 'posts/no_posts' %>
-        </div>
-    <% end %>
+    <!-- 投稿されてないタグを使って検索できない仕様ですが、念の為に設置 -->
+    <%= render 'shared/posts/existence_or_empty', post: @posts %>
+
 </div>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -14,13 +14,6 @@
     </div>
 </div>
 
-    <% if @posts.present? %>
-        <div class="flex flex-wrap justify-center gap-1">
-            <%= render @posts %>
-        </div>
-    <% else %>
-        <div class="my-10">
-            <%= render 'no_posts' %>
-        </div>
-    <% end %>
+    <%= render 'shared/posts/existence_or_empty', post: @posts %>
+
 </div>


### PR DESCRIPTION
# fix: ビューのテンプレを増やして整理
# （投稿がない場合とGoogleログインボタン）
該当issue：#284
**できるようになったこと**
- ユーザーにとっては変化なし
____
- **不要なファイルを削除**
  - `app/views/google_login_api/callback.html.erb`を削除
  - `app/views/posts/_no_posts.html.erb`を削除
- **Googleログインボタンのテンプレ化**
  - `app/views/shared/_googleloginbutton.html.erb`を生成：Googleログインボタンだけのテンプレ
  - `app/views/shared/header/_googleloginbutton_or_logo.html.erb`：テンプレ呼び出し
- **投稿がない場合のテンプレを整理・用意**
  - `app/views/shared/posts`ディレクトリを用意
  - `app/views/shared/posts/_empty_posts_text.html.erb`を生成：`投稿しよう`テキストのみのテンプレ
  - `app/views/shared/posts/_existence_or_empty.html.erb`を生成：投稿の有無で呼び出すテンプレを分岐
  - `app/views/shared/posts/_new_posts_button.html.erb`を生成：投稿画面へ遷移するボタンのテンプレ
  - `app/views/shared/posts/_index_button.html.erb`を生成：`みんなの投稿一覧`へ遷移するボタンのテンプレ
- **投稿がない場合のテンプレを呼び出し**
  - `app/views/posts/index.html.erb`（みんなの投稿一覧）
  - `app/views/search_posts/search.html.erb`（投稿の検索結果一覧）
  - `app/views/tags/show.html.erb`（タグの絞り込み検索結果一覧）
    - 投稿されてないタグを使って検索できない仕様ですが、念の為に設置
  - `app/views/users/posts/index.html.erb`（自作したあるある一覧）
  - `app/views/search_posts/autocomplete.html.erb`（検索フォームのオートコンプリート）
- **`遊んだみんなの感想をXで見る`ボタンをオレンジ色に変更**
  - `app/views/shared/_xreview_button.html.erb`
