### PR TITLE
fix: AI機能実装に備え、送信するフォームをテンプレ化（文字数制限付き） close #287

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,7 +14,7 @@
         </div>
     </div>
 
-    <%= f.label :aruarus, "あるあるを５つ、入力してね！", class: "label text-[#0088D0] text-xs pb-0" %>
+    <%= f.label :aruarus, "この界隈ならではのあるあるを、５つ入力してね！", class: "label text-[#0088D0] text-xs pb-0" %>
         <% [:aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five].each_with_index do |field, index| %>
             <div class="relative mt-2" data-controller="character-counter" data-character-counter-countdown-value="true">
                 <%= f.text_area field, id: field, autofocus: true,
@@ -36,7 +36,7 @@
     <!-- タグを登録するフォーム -->
     <%= f.label :tag, "この界隈に関連するワードは？", class: "label text-[#0088D0] text-xs p-0" %>
     <!-- value:@tagsでタグの配列を取得 -->
-    <%= f.text_field :tag, placeholder: "漫画 アニメ ジャンプ",
+    <%= f.text_field :tag, placeholder: "例：漫画 アニメ ジャンプ",
         class: "border-2 border-sky-300 rounded-md w-72
             text-sm text-orange-500 font-bold placeholder:font-light placeholder:text-[#C7C7C7]",
         value: @tags %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed z-50 w-full h-14 bg-base-100 bottom-0 bg-yellow-50 border-t-2 border-white">
+<div class="fixed z-50 w-full h-16 bg-base-100 bottom-0 bg-yellow-50 border-t-2 border-white">
     <div class="flex h-full max-w-lg mx-auto justify-evenly">
 
     <div class="menu-list1 text-xs text-[#019c8f] hover:text-[#00e297] flex items-center justify-center">

--- a/app/views/shared/_googleloginbutton.html.erb
+++ b/app/views/shared/_googleloginbutton.html.erb
@@ -1,6 +1,8 @@
 <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false },
-    class: "btn btn-sm gap-1 font-semibold rounded-full bg-white hover:border-orange-500 hover:bg-white" do %>
+    class: "btn btn-sm gap-1 font-semibold rounded-full bg-white hover:border-orange-500 hover:bg-white drop-shadow-md hover:drop-shadow-none" do %>
+
     <img width="20" height="20" alt="Googleログイン" class="inline-block"
         src="https://img.icons8.com/external-those-icons-flat-those-icons/24/external-Google-logos-and-brands-those-icons-flat-those-icons.png"/>
     <span class="text-xs text-gray-400 font-light">ログイン</span>
+
 <% end %>

--- a/app/views/shared/posts/_index_button.html.erb
+++ b/app/views/shared/posts/_index_button.html.erb
@@ -1,8 +1,8 @@
 <div class="menu-list1" >
-<%= link_to image_tag('footer/menu/menu-1.svg', width: '25', height: '25', id: 'image-menu1') + 'みんなの投稿で遊ぶ',
-    posts_path,
-    class: "btn btn-md items-center no-underline rounded-lg w-hull px-2 mb-2 p-0 gap-2
-            font-bold text-nowrap text-[#019c8f] hover:text-[#00e297]
-            bg-white hover:bg-white border-2 hover:border-orange-400
-            drop-shadow-md hover:drop-shadow-none" %>
+    <%= link_to image_tag('footer/menu/menu-1.svg', width: '25', height: '25', id: 'image-menu1') + 'みんなの投稿で遊ぶ',
+        posts_path,
+        class: "btn btn-md items-center no-underline rounded-lg w-hull px-2 mb-2 p-0 gap-2
+                font-bold text-nowrap text-[#019c8f] hover:text-[#00e297]
+                bg-yellow-50 hover:bg-white border-2 border-white hover:border-orange-400
+                drop-shadow-md hover:drop-shadow-none" %>
 </div>

--- a/app/views/shared/posts/_new_posts_button.html.erb
+++ b/app/views/shared/posts/_new_posts_button.html.erb
@@ -1,8 +1,8 @@
 <div class="menu-list2" >
     <%= link_to image_tag('footer/menu/menu-2.svg', width: '25', height: '25', id: 'image-menu2') + '自分であるあるを投稿',
         new_post_path,
-        class: "btn btn-md items-center no-underline rounded-lg w-hull px-2 mb-2 p-0 gap-2
+        class: "btn btn-md items-center no-underline rounded-lg w-hull px-2 mb-2 gap-2
                 font-bold text-nowrap text-[#0088D0] hover:text-[#00c5ff]
-                bg-white hover:bg-white border-2 hover:border-orange-400
+                bg-yellow-50 hover:bg-white border-2 border-white hover:border-orange-400
                 drop-shadow-md hover:drop-shadow-none" %>
 </div>

--- a/app/views/tops/_openai_form.html.erb
+++ b/app/views/tops/_openai_form.html.erb
@@ -1,0 +1,39 @@
+<form id="myForm" class="font-light text-lg text-[#0090e3] ">
+<label for="inputData" class="block mb-2 text-center">どの界隈のあるあるで遊ぶ？🤔</label>
+    <div class="flex justify-center mb-4">
+        <input type="text" placeholder="未実装だよ！待っててね！" id="inputData" name="inputData"
+            class="w-[360px] p-2 border-4 border-[#ffa463] rounded text-left font-family-['BIZ UDGothic'] placeholder-[#cecece]"
+            maxlength="40" />
+    </div>
+
+    <div class="flex justify-center relative inline-block">
+        <a href="#" class="start-btn opacity-1 transition-all duration-300 flex items-center justify-center rounded-md">
+            <div class="start-btn-content shadow-md
+                        flex w-[260px] h-[70px] border-4 border-white rounded-[40px] bg-[#ffdde0]
+                        perspective-[150px] transform-style-[preserve-3d]">
+                <style>
+                    .start-btn:hover .start-btn-front {opacity: 0; /* 表面文字を非表示 */}
+                    .start-btn:hover .start-btn-back {opacity: 1; /* 裏面文字を表示 */}
+                    .start-btn:hover .start-btn-content {
+                        -webkit-transform: rotateX(0.5turn) rotateX(-0.03turn);
+                        transform: rotateX(0.5turn) rotateX(-0.03turn);
+                        -webkit-transition-duration: 0.5s; /* 古いWebKitブラウザ用 */
+                        transition-duration: 0.5s; /* 標準ブラウザ用 */
+                        background: #f2f5f6; }
+                </style>
+                <div class="start-btn-front duration-500
+                            text-[#ff426b] font-bold text-lg whitespace-nowrap absolute
+                            top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2
+                            transition-opacity duration-500 opacity-100 ">
+                    神経衰弱スタート
+                </div>
+                <div class="start-btn-back duration-300 rotate-180 -scale-x-100
+                            text-[#52b1ff] font-bold text-lg whitespace-nowrap absolute
+                            top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2
+                            transition-opacity opacity-0 hover:opacity-100">
+                    あるあるを知ろう！
+                </div>
+            </div>
+        </a>
+    </div>
+</form>

--- a/app/views/tops/toppage.html.erb
+++ b/app/views/tops/toppage.html.erb
@@ -18,43 +18,7 @@
         <%= render 'tops/howto' %>
     </div>
 
-    <form id="myForm" class="font-light text-lg text-[#0090e3] ">
-        <label for="inputData" class="block mb-2 text-center">どの界隈のあるあるで遊ぶ？🤔</label>
-        <div class="flex justify-center mb-4">
-            <input type="text" placeholder="未実装だよ！待っててね！" id="inputData" name="inputData"
-                class="w-[360px] p-2 border-4 border-[#ffa463] rounded text-left font-family-['BIZ UDGothic'] placeholder-[#cecece]" />
-        </div>
+    <%= render 'openai_form' %>
 
-        <div class="flex justify-center relative inline-block">
-            <a href="#" class="start-btn opacity-1 transition-all duration-300 flex items-center justify-center rounded-md">
-                <div class="start-btn-content shadow-md
-                            flex w-[260px] h-[70px] border-4 border-white rounded-[40px] bg-[#ffdde0]
-                            perspective-[150px] transform-style-[preserve-3d]">
-                    <style>
-                        .start-btn:hover .start-btn-front {opacity: 0; /* 表面文字を非表示 */}
-                        .start-btn:hover .start-btn-back {opacity: 1; /* 裏面文字を表示 */}
-                        .start-btn:hover .start-btn-content {
-                            -webkit-transform: rotateX(0.5turn) rotateX(-0.03turn);
-                            transform: rotateX(0.5turn) rotateX(-0.03turn);
-                            -webkit-transition-duration: 0.5s; /* 古いWebKitブラウザ用 */
-                            transition-duration: 0.5s; /* 標準ブラウザ用 */
-                            background: #f2f5f6; }
-                    </style>
-                    <div class="start-btn-front duration-500
-                                text-[#ff426b] font-bold text-lg whitespace-nowrap absolute
-                                top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2
-                                transition-opacity duration-500 opacity-100 ">
-                        神経衰弱スタート
-                    </div>
-                    <div class="start-btn-back duration-300 rotate-180 -scale-x-100
-                                text-[#52b1ff] font-bold text-lg whitespace-nowrap absolute
-                                top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2
-                                transition-opacity opacity-0 hover:opacity-100">
-                        あるあるを知ろう！
-                    </div>
-                </div>
-            </a>
-        </div>
-    </form>
 </body>
 </html>


### PR DESCRIPTION
該当issue：#287

**ビュー**
- **AIにお題を送信するフォームをテンプレ化（文字数制限付き）**
  - `app/views/tops/_openai_form.html.erb`：テンプレ
  - `app/views/tops/toppage.html.erb`：テンプレ呼び出し
- **CSSの微調整**
  - `app/views/posts/_form.html.erb`：投稿フォームのラベルを変更
  - `app/views/shared/_footer.html.erb`：フッターに縦幅を追加
  - `app/views/shared/posts/_index_button.html.erb`
  - `app/views/shared/posts/_new_posts_button.html.erb`
  - `app/views/shared/_googleloginbutton.html.erb`
  ____
**しなかったこと**
Github  Actions（CI）の修正は別ブランチ・別プルリクで行います