### PR TITLE
fix: 既存のユーザー名に変更しようとすると「お名前を入力してね」と表示されてしまう close #291

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,10 +5,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   def update_resource(resource, params)
-    if resource.update_without_password(params)
+    if params[:name].blank?
+      resource.errors.add(:name, :blank)
+      flash.now[:alert] = I18n.t("devise.registrations.edit.empty_name")
+      false
+    elsif resource.update(params)
       true
     else
-      flash.now[:alert] = I18n.t("devise.registrations.edit.no_name")
+      flash.now[:alert] = I18n.t("devise.registrations.edit.name_taken", html: true)
       false
     end
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,14 +1,13 @@
 <div class="flex justify-center items-center mt-6">
     <div id="profile" class="area w-80 md:w-96 bg-base-100 rounded-lg">
         <div class="area-body items-center text-center p-4">
-        <div class="flex">
             <%= form_with model: @user, url: user_registration_path, method: :put do |f| %>
                 <div class="m-2">
 
                     <%= f.label :name, "きみのお名前は？", class: "text-xl text-cyan-700 font-bold" %>
                     <%= f.text_field :name, autofocus: true,
                         class: "input input-bordered border-2 border-sky-300
-                                rounded-md w-60 text-orange-500 font-bold" %>
+                                rounded-md w-60 text-orange-500 font-bold mt-4" %>
                 </div>
 
                 <%= f.submit "変更",
@@ -19,8 +18,7 @@
                     <%= link_to 'キャンセル', myindex_posts_path,
                         class: "text-sm text-blue-600 hover:text-blue-500 hover:font-bold drop-shadow-md hover:drop-shadow-none" %>
                 </div>
-                <% end %>
-            </div>
+            <% end %>
         </div>
     </div>
 </div>

--- a/app/views/games/_clear_modal.html.erb
+++ b/app/views/games/_clear_modal.html.erb
@@ -6,7 +6,7 @@
             <% if @post.user.name == "OPEN_AI_ANSWER" %>
 
                 <!-- AIが生成したあるあるで遊んだあとの場合 -->
-                <h3 class="text-xl leading-6 font-bold text-pink-500 py-4">🙄　界隈探求クリア？？？　🙄</h3>
+                <h3 class="text-xl leading-6 font-bold text-pink-500 py-4">🙄　界隈探求クリア？？　🙄</h3>
                 <div class="text-sm text-pink-500">どう思った〜？？<br><br>きみの好きな界隈のあるあるを
                     <%= render "shared/login_status" %>
                 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
   <body class="bg-custom-yellow">
     <%= render 'shared/header' %>
 
-    <div class="pt-[56px] pb-[70px]">
+    <div class="pt-[68px] pb-[70px]">
       <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,13 +1,13 @@
-<div class="flex inset-0 justify-center items-center pt-2 my-2">
+<div class="flex inset-0 justify-center items-center">
 
     <% if notice.present? %>
-        <p class="py-2 px-3 bg-green-50 text-green-500 font-medium rounded-lg inline-block" id="notice">
+        <p class="my-2 py-2 px-3 bg-green-50 text-green-500 font-medium rounded-lg inline-block" id="notice">
         <%= notice %></p>
     <% end %>
 
     <% if alert.present? %>
-        <p class="py-2 px-3 bg-orange-50 text-red-500 font-bold rounded-lg border-2 border-orange-400 inline-block" id="alert">
-        <%= alert %></p>
+        <p class="my-2 py-2 px-3 bg-orange-50 text-red-500 font-bold rounded-lg border-2 border-orange-400 inline-block" id="alert">
+        <%= alert.html_safe %></p>
     <% end %>
 
 </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -48,8 +48,8 @@ ja:
         unhappy: "気に入りません"
         update: "更新"
         we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
-        # 追加
-        no_name: "お名前を入力してね"
+        name_taken: "すでに使われてるお名前だから<br>表記かえたり、数字つけたりしてみてね！"  # 追加
+        empty_name: "お名前を入力してね！"  # 追加
         update_success: "OK！きみは、%{name}さんだね！"
       new:
         sign_up: "アカウント登録"


### PR DESCRIPTION
# fix: 既存のユーザー名に変更しようとすると「お名前を入力してね」と表示されてしまう
該当issue： #291
**できるようになったこと**
- 既存のユーザー名に変更しようとすると、使えない旨がメッセージで表示
  - https://aruaru-games.com/users/edit （ユーザー名変更画面）
[![Image from Gyazo](https://i.gyazo.com/caaed88e5cddf53e99f1a49f18cc0f07.gif)](https://gyazo.com/caaed88e5cddf53e99f1a49f18cc0f07)
____
**実装**
- `app/controllers/users/registrations_controller.rb`
  - 更新しようとしてるユーザー名が、空か否かで条件分岐
    - 空ならメッセージを表示
    - 入力されたユーザー名が既存でなければ、更新
    - 入力されたユーザー名が既存であれば、メッセージを表示
- `config/locales/devise.views.ja.yml`：ユーザー名更新時の日本語メッセージを設定（HTMLの書き方で改行してます）
- `app/views/shared/_flash_message.html.erb`：HTMLの書き方が適応するように設定

**しなかったこと**
- Github Actions（CI）の修正は別ブランチ・別プルリクで行います
____
以下のファイルの変更はCSS調整やインデント修正など、今回の実装とは無関係の内容。
- CSS微調整
  - `app/views/devise/registrations/edit.html.erb`：不要な`div`タグを削除
  - `app/views/games/_clear_modal.html.erb`：モーダルの不要な記載を削除
  - `app/views/layouts/application.html.erb`：ボディの高さを微調整
____
