### PR TITLE
fix:  認証失敗時の処理をカスタマイズを先に定義、セキュリティを高める close #295

### DIFF
--- a/lib/custom_authentication_failure.rb
+++ b/lib/custom_authentication_failure.rb
@@ -1,6 +1,16 @@
 class CustomAuthenticationFailure < Devise::FailureApp
     protected
 
+    def respond
+        # 認証失敗時の処理をカスタマイズするメソッド
+        if http_auth?
+            http_auth
+        else
+            redirect
+        end
+    end
+
+    # 認証失敗時のリダイレクト先を指定するメソッド
     def redirect_url
         # Warden（Devise)が内部で使っている認証ライブラリ）のオプションの一部で、現在の認証スコープを示す
         # ユーザーの種類やロールを特定するために使われる
@@ -8,15 +18,6 @@ class CustomAuthenticationFailure < Devise::FailureApp
             root_path
         else
             super
-        end
-    end
-
-    def respond
-        # HTTP認証を使ってレスポンスを返すhttp_authメソッドを呼び出す
-        if http_auth?
-            http_auth
-        else
-            redirect
         end
     end
 end


### PR DESCRIPTION
# 認証失敗時の処理をカスタマイズを先に定義し、セキュリティを高める
該当issue：#295
**できるようになったこと**
- 認証失敗時の処理をカスタマイズを先に定義し、セキュリティを高めた


**修正前**
  - 前回のデプロイ時にRenderのログにこのエラーが表示されていました
    ```bash
    # CustomAuthenticationFailure クラスに respond メソッドが定義されていない
    AbstractController::ActionNotFound (The action 'respond' could not be found for CustomAuthenticationFailure
    ```
____
**実装**
- `lib/custom_authentication_failure.rb`
  - `respond`（認証失敗時の処理をカスタマイズするメソッド）を  
    `def redirect_url`（認証失敗時のリダイレクト先を指定するメソッド）の上に入れ替えた
_____
**目的**
- リダイレクト先よりも、先に`respond`の定義を読んでもらうため
   先に定義を読んでもらうことで、クラスの中心となる部分が明確になる
- `redirect_url`メソッドは`respond`メソッドにありきのメソッドなので、`respond`メソッドを先に読ませセキュリティを高められる
