### PR TITLE
add: 動的OGPに使うテキストを、minimagick用に`UTF-8`に変換 close #296

### DIFF
--- a/app/controllers/concerns/ogp_creator.rb
+++ b/app/controllers/concerns/ogp_creator.rb
@@ -11,7 +11,9 @@ class OgpCreator
 
   def self.build(text)
     text_a, text_b = text.split("\n", 2) # AとBに分離
+    text_a = text_a.force_encoding("UTF-8") # minimagick用に、UTF-8に変換
     text_b = prepare_text(text_b)
+    text_b = text_b.force_encoding("UTF-8") # minimagick用に、UTF-8に変換
     image = MiniMagick::Image.open(BASE_IMAGE_PATH)
 
     image.combine_options do |config|
@@ -35,6 +37,7 @@ class OgpCreator
   end
 
   def self.prepare_text(text)
-    text.to_s.scan(/.{1,#{INDENTION_COUNT}}/)[0...ROW_LIMIT].join("\n")
+    text = text.to_s.force_encoding("UTF-8") # minimagick用に、UTF-8に変換
+    text.scan(/.{1,#{INDENTION_COUNT}}/)[0...ROW_LIMIT].join("\n")
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -7,6 +7,8 @@ class GamesController < ApplicationController
     if @post && @post.user.name != "OPEN_AI_ANSWER"
       ogp_image_url = generate_and_save_ogp(@post)
       set_meta_tags(og: { image: ogp_image_url }, twitter: { image: ogp_image_url })
+    else
+      Rails.logger.info("OGPを生成しない: AIが生成した投稿です")
     end
   end
 


### PR DESCRIPTION
# add: 動的OGPに使うテキストを、minimagick用に`UTF-8`に変換
該当issue： #296
**変更前**
- 本番環境で、動的OGPを生成/保存時にエラーログが出てる。
```bash
Started POST "/posts"
 Processing by PostsController#create as TURBO_STREAM
   Parameters: {"authenticity_token"=>"[FILTERED]", "post"=>{"title"=>"省略...., "commit"=>"投稿ぉ"}
 Completed 500 Internal Server Error in 310ms (ActiveRecord: 44.6ms | Allocations: 4135)
 ERROR -- : 
 Encoding::CompatibilityError (incompatible character encodings: UTF-8 and ASCII-8BIT):

 app/controllers/concerns/ogp_creator.rb:17:in `build'
 app/controllers/posts_controller.rb:81:in `post_params'
 app/controllers/posts_controller.rb:39:in `create'
```

**変更内容**
- `app/controllers/concerns/ogp_creator.rb`：動的OGPに使うテキストを、minimagick用に`UTF-8`に変換する追記
- `app/controllers/games_controller.rb`：AIが生成した投稿を受け取った場合はログを表示

**変更後**
[![Image from Gyazo](https://i.gyazo.com/3fd9a3dfb8e68880f490e0854bbc7b79.png)](https://gyazo.com/3fd9a3dfb8e68880f490e0854bbc7b79)