### PR TITLE
add: ローディングアニメーション close #223

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -63,3 +63,10 @@
     background-color: white;
     box-shadow: none;
     border: 2px solid rgb(255, 132, 0, 0.827); }
+
+
+
+/* ローディングアニメーション */
+.loaded {
+    opacity: 0;
+    display: none; }

--- a/app/javascript/loading.js
+++ b/app/javascript/loading.js
@@ -1,0 +1,28 @@
+console.log("loading.js が読み込めました");
+
+document.addEventListener("turbo:load", function() {
+    const links = document.querySelectorAll("a[data-loading]");
+    const loadingAnimation = document.getElementById("loading"); // id="loading" を格納
+    const body = document.querySelector("body");  // <body> 要素を取得し、body 変数に格納
+
+    // links 変数に格納された全ての <a> タグ要素に、クリックイベントリスナーを設定
+    links.forEach(link => {
+        link.addEventListener("click", function(event) {
+            showLoadingAnimation();  });  });
+
+    // AI生成のフォーム送信時のイベントリスナー
+    const form = document.getElementById("myForm");
+    if (form) {
+        form.addEventListener("submit", function(event) { // submitイベントが発火し、その際に指定した関数が実行されるように設定
+            event.preventDefault(); // フォーム送信を停止（ページがリロードされずに次の処理が行える）
+            showLoadingAnimation(); // ローディングアニメーションを表示す
+            this.submit();  }); }   // フォームを送信（thisはイベントリスナー内ではformを指すので、フォームが送信）
+
+    function showLoadingAnimation() {
+        // ローディングアニメーションを表示
+        // style.display を "flex" に設定し、hidden クラスを削除し、flex クラスを追加することで、ローディングアニメーションを表示
+        loadingAnimation.style.display = "flex";
+        loadingAnimation.classList.remove("hidden");
+        loadingAnimation.classList.add("flex");
+        body.classList.add("overflow-hidden"); } // スクロール禁止
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,8 @@
       <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
 
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-    <%= javascript_include_tag "games", type: "module" %>
+    <%= javascript_include_tag "games", "data-turbo-track": "reload", type: "module" %>
+    <%= javascript_include_tag "loading", "data-turbo-track": "reload", type: "module" %>
 
     <!-- 静的OGP（ゲーム画面のみ動的OGP） -->
     <%= display_meta_tags(default_meta_tags) %>
@@ -38,6 +39,7 @@
 
     <%= render 'shared/footer' %>
 
+    <%= render 'shared/load_animation' %>
     <% if request.path == "/games/#{params[:id]}/start" %>
       <%= render 'games/clear_modal' %>
     <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,8 +2,8 @@
     <% if current_user == post.user %>
 
         <!-- カレントユーザーが自作した投稿（myindex） -->
-        <%= link_to start_game_path(post),
-            class: "block post-box bg-cyan-50 border-2 border-cyan-100 rounded-lg shadow-md
+        <%= link_to start_game_path(post), data: { loading: true },
+            class: "start-game block post-box bg-cyan-50 border-2 border-cyan-100 rounded-lg shadow-md
                     hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
 
             <!-- 自作投稿一覧以外に表示する場合は、カレントユーザー名を表示 -->
@@ -37,8 +37,8 @@
     <% else %>
 
         <!-- 他のユーザーが投稿した一覧（index） -->
-        <%= link_to start_game_path(post),
-            class: "block post-box bg-green-50 border-2 border-green-100 rounded-lg shadow-md
+        <%= link_to start_game_path(post), data: { loading: true },
+            class: "start-game block post-box bg-green-50 border-2 border-green-100 rounded-lg shadow-md
                     hover:bg-white hover:shadow-none hover:border-2 hover:border-orange-400" do %>
             <div id="post-id-<%= post.id %>" class="text-left">
             <ul class="list-inline text-slate-400 text-xs px-2 pt-2"><%= post.user.name %>さんが思う</ul>

--- a/app/views/shared/_load_animation.html.erb
+++ b/app/views/shared/_load_animation.html.erb
@@ -1,0 +1,7 @@
+<div id="loading" class="hidden bg-orange-300 bg-opacity-50 fixed top-0 left-0 w-full h-full z-50 flex items-center justify-center">
+    <div class="bg-yellow-50 p-28 rounded-xl">
+        <div class="animate-spin">
+                <%= image_tag 'logo-clear.png', class: 'w-32 h-32 aspect-[1/1]' %>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
# add: ローディングアニメーション
該当issue：#223
**できるようになったこと**
-  ゲーム画面に遷移する読み込み時間中に、ローディングアニメーションを表示
    - https://aruaru-games.com/posts （他者投稿一覧）
    - https://aruaru-games.com/posts/myindex （自作投稿一覧）
    - https://aruaru-games.com/search_posts/search? （検索結果一覧）
    - https://aruaru-games.com/tags/タグID （タグの検索結果一覧）
[![Image from Gyazo](https://i.gyazo.com/27a847b6e1f26d4c9563bc59758f5e55.gif)](https://gyazo.com/27a847b6e1f26d4c9563bc59758f5e55)
    - https://aruaru-games.com （AIで投稿を生成できる画面）
[![Image from Gyazo](https://i.gyazo.com/0375709e4f5867852a2b1de46984a210.gif)](https://gyazo.com/0375709e4f5867852a2b1de46984a210)
____
**実装**
参考記事：[CSSとJavaScriptでWebページにローディングアニメーションを表示させる方法](https://www.webcreatorbox.com/blog/loading-animation#:~:text=3.%20%E3%83%9A%E3%83%BC%E3%82%B8%E5%85%A8%E4%BD%93%E3%82%92%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%82%93%E3%81%A0%E3%82%89%E3%83%AD%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E7%94%BB%E9%9D%A2%E3%82%92%E9%9D%9E%E8%A1%A8%E7%A4%BA%E3%81%AB%E3%81%99%E3%82%8B)
- `app/assets/stylesheets/application.tailwind.css`：ローディングアニメーションのビューを非表示に
- `app/javascript/loading.js`：
  - ローディングアニメーションを表示/非表示する処理を設定
  - ゲーム画面へ遷移するきっかけを設定
    - 投稿一覧などから、ゲーム画面へ遷移するリンクをクリックした際のリスナー
    - AI生成のフォーム送信し、ゲーム画面へ遷移する際のイベントリスナー
- `app/views/layouts/application.html.erb`：`loading.js`とローディングアニメーションのビューを呼び出し
- `app/views/posts/_post.html.erb`：ゲーム画面へ遷移するリンクを、`loading.js`と紐付け
- `app/views/shared/_load_animation.html.erb`を生成：ローディングアニメーションのビュー（アプリロゴを回転）
- **開発環境用にゲーム画面の読み込みを遅らせた**（今回の実装を完了後に削除する記載）
  - `app/controllers/games_controller.rb`の`start`アクションに`sleep 5`を追記
____