### PR TITLE
fix: ゲーム画面に遷移後、ブラウザバックしてもローディングアニメーションが表示されないよう修正 close #299

### DIFF
--- a/app/javascript/loading.js
+++ b/app/javascript/loading.js
@@ -5,17 +5,27 @@ document.addEventListener("turbo:load", function() {
     const loadingAnimation = document.getElementById("loading"); // id="loading" を格納
     const body = document.querySelector("body");  // <body> 要素を取得し、body 変数に格納
 
+    // ローディングアニメーションを非表示にする関数
+    function hideLoadingAnimation() {
+        loadingAnimation.style.display = "none";
+        loadingAnimation.classList.remove("flex");
+        loadingAnimation.classList.add("hidden");
+        body.classList.remove("overflow-hidden"); }
+
     // links 変数に格納された全ての <a> タグ要素に、クリックイベントリスナーを設定
     links.forEach(link => {
         link.addEventListener("click", function(event) {
-            showLoadingAnimation();  });  });
+            showLoadingAnimation();
+            // ゲーム画面へ遷移が完了したら、ローディングアニメーションを非表示にする
+            window.addEventListener("turbo:render", function() {
+                hideLoadingAnimation(); });  }); });
 
     // AI生成のフォーム送信時のイベントリスナー
     const form = document.getElementById("myForm");
     if (form) {
         form.addEventListener("submit", function(event) { // submitイベントが発火し、その際に指定した関数が実行されるように設定
             event.preventDefault(); // フォーム送信を停止（ページがリロードされずに次の処理が行える）
-            showLoadingAnimation(); // ローディングアニメーションを表示す
+            showLoadingAnimation(); // ローディングアニメーションを表示する
             this.submit();  }); }   // フォームを送信（thisはイベントリスナー内ではformを指すので、フォームが送信）
 
     function showLoadingAnimation() {

--- a/app/views/shared/_load_animation.html.erb
+++ b/app/views/shared/_load_animation.html.erb
@@ -1,7 +1,10 @@
 <div id="loading" class="hidden bg-orange-300 bg-opacity-50 fixed top-0 left-0 w-full h-full z-50 flex items-center justify-center">
-    <div class="bg-yellow-50 p-28 rounded-xl">
-        <div class="animate-spin">
-                <%= image_tag 'logo-clear.png', class: 'w-32 h-32 aspect-[1/1]' %>
+    <div class="bg-yellow-50 p-20 rounded-xl">
+        <%= image_tag 'logo-clear.png', class: 'w-32 h-32 aspect-[1/1]' %>
+        <div class="flex justify-center mt-8">
+            <div class="animate-ping h-2 w-2 bg-pink-600 rounded-full"></div>
+            <div class="animate-ping h-2 w-2 bg-pink-600 rounded-full mx-8"></div>
+            <div class="animate-ping h-2 w-2 bg-pink-600 rounded-full"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
# fix: ゲーム画面に遷移後、ブラウザバックしてもローディングアニメーションが表示されないよう修正
該当issue：#299
**修正前**
- ゲーム画面に遷移後、ブラウザバックするとまだローディングアニメーションが表示される  
  [![Image from Gyazo](https://i.gyazo.com/cb9adc07c9dcf87350f99ccbca85a367.gif)](https://gyazo.com/cb9adc07c9dcf87350f99ccbca85a367)

**修正後**
- ゲーム画面に遷移後、ブラウザバックしてもローディングアニメーションが表示されない  
  [![Image from Gyazo](https://i.gyazo.com/d3531016bba75dcf1db99e2d0f0fed2c.gif)](https://gyazo.com/d3531016bba75dcf1db99e2d0f0fed2c)
____
**実装**
fix: ローディングアニメーション
- `app/javascript/loading.js`：ゲーム画面へ遷移が完了したらローディングアニメーションを非表示する処理を追記
- `app/views/shared/_load_animation.html.erb`：ビューを変更

**しなかったこと**
- **AIで投稿を生成し**ゲーム画面に遷移後、ブラウザバックするとローディングアニメーションが表示されるのを修正
  - AIで投稿を生成したゲーム画面では、元々「ブラウザバックで戻ると、もう遊べないよ」と注意喚起しているので
    この場面でブラウザバックをするユーザーが少ないという点から、修正しませんでした。 
     [![Image from Gyazo](https://i.gyazo.com/60be11a361b8d6141f37da5e16f1af70.gif)](https://gyazo.com/60be11a361b8d6141f37da5e16f1af70)
