### PR TITLE
fix: 投稿名で`'`を入力できるようにする close #300

### DIFF
--- a/app/controllers/concerns/ogp_creator.rb
+++ b/app/controllers/concerns/ogp_creator.rb
@@ -11,9 +11,9 @@ class OgpCreator
 
   def self.build(text)
     text_a, text_b = text.split("\n", 2) # AとBに分離
-    text_a = text_a.force_encoding("UTF-8") # minimagick用に、UTF-8に変換
+    text_a = text_a.gsub("'", "’").force_encoding("UTF-8") # シングルクォーテーションは右シングルクォーテーションに変換、minimagick用に、UTF-8に変換
     text_b = prepare_text(text_b)
-    text_b = text_b.force_encoding("UTF-8") # minimagick用に、UTF-8に変換
+    text_b = text_b.gsub("'", "’").force_encoding("UTF-8") # シングルクォーテーションは右シングルクォーテーションに変換、minimagick用に、UTF-8に変換
     image = MiniMagick::Image.open(BASE_IMAGE_PATH)
 
     image.combine_options do |config|
@@ -37,7 +37,7 @@ class OgpCreator
   end
 
   def self.prepare_text(text)
-    text = text.to_s.force_encoding("UTF-8") # minimagick用に、UTF-8に変換
+    text = text.to_s.gsub("'", "’").force_encoding("UTF-8") # シングルクォーテーションは右シングルクォーテーションに変換、minimagick用に、UTF-8に変換
     text.scan(/.{1,#{INDENTION_COUNT}}/)[0...ROW_LIMIT].join("\n")
   end
 end


### PR DESCRIPTION
# fix: 投稿名で`'`の入力できるようにする
該当issue：#300
**修正前**
- 投稿名で`'`とその後に文字を入力するとエラーになる  
  [![Image from Gyazo](https://i.gyazo.com/3e2c355ff28f571a39b33498ee316176.gif)](https://gyazo.com/3e2c355ff28f571a39b33498ee316176)

**修正後**
- 投稿名で`'`とその後に文字を入力できる。OGPも生成できる。
[![Image from Gyazo](https://i.gyazo.com/a50f0b5d7b19b170e5c1899c6038134b.gif)](https://gyazo.com/a50f0b5d7b19b170e5c1899c6038134b)
____
**実装**
fix: 投稿名で`'`の入力できるようにする
- `app/controllers/concerns/ogp_creator.rb`
  - 投稿名にある`'`（シングルクォーテーション）は、`’`（右シングルクォーテーション）に変換して動的OGPを生成する

**しなかったこと**
- 投稿名にある`'`（シングルクォーテーション）でOGPを生成
  - どうしても`'`（シングルクォーテーション）でOGPが生成できず、「Bzz」という表記で生成されてしまいます
  - なので`'`（シングルクォーテーション）は、`’`（右シングルクォーテーション）に変換してOGPを生成させています
