### PR TITLE
fix: Googleアナリティクスを本番環境のみで集計させる

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-7M5YD1J9TK"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-7M5YD1J9TK');
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,15 +18,10 @@
     <!-- 静的OGP（ゲーム画面のみ動的OGP） -->
     <%= display_meta_tags(default_meta_tags) %>
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7M5YD1J9TK"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-7M5YD1J9TK');
-    </script>
+    <!-- Googleアナリティクス -->
+    <% if Rails.env.production? %>
+      <%= render 'layouts/google_analytics' %>
+    <% end %>
   </head>
 
   <body class="bg-custom-yellow">


### PR DESCRIPTION
# fix: Googleアナリティクスを本番環境のみで集計させる
**実装**
- `app/views/layouts/_google_analytics.html.erb`：Google tag をテンプレ化
- `app/views/layouts/application.html.erb`
  - 本番環境の場合はGoogleアナリティクスを適応（Google tag テンプレを呼び出し）
