### PR TITLE
add: Cookieが盗まれるリスクを減らす close #317

### DIFF
--- a/app/controllers/openai_posts_controller.rb
+++ b/app/controllers/openai_posts_controller.rb
@@ -26,7 +26,8 @@ class OpenaiPostsController < ApplicationController
         Time.zone = "Tokyo"
         # secure: 本番環境で動いているときだけクッキーはHTTPSを使って配送され、クッキーが盗まれるリスクを減らす
         # httponly: JavaScriptからそのクッキーにアクセスできなくり、XSS攻撃でクッキーが盗まれにくくなる
+        # samesite: CSRF対策
         cookies[:cookie_count] = { value: Time.zone.today.to_s, expires: Time.zone.now + 1.day,
-                                    secure: Rails.env.production?,  httponly: true }
+                                    secure: Rails.env.production?,  httponly: true, same_site: :lax }
     end
 end

--- a/app/controllers/openai_posts_controller.rb
+++ b/app/controllers/openai_posts_controller.rb
@@ -24,6 +24,9 @@ class OpenaiPostsController < ApplicationController
 
         # cookieに保存（日本時間で1日後に期限切れ）
         Time.zone = "Tokyo"
-        cookies[:cookie_count] = { value: Time.zone.today.to_s, expires: Time.zone.now + 1.day }
+        # secure: 本番環境で動いているときだけクッキーはHTTPSを使って配送され、クッキーが盗まれるリスクを減らす
+        # httponly: JavaScriptからそのクッキーにアクセスできなくり、XSS攻撃でクッキーが盗まれにくくなる
+        cookies[:cookie_count] = { value: Time.zone.today.to_s, expires: Time.zone.now + 1.day,
+                                    secure: Rails.env.production?,  httponly: true }
     end
 end


### PR DESCRIPTION
# add: Cookieが盗まれるリスクを減らす
該当issue：#317
**修正前**
ユーザーにcookieを持たせる実装 https://github.com/pakira-56A/aruaru-game/pull/290 をマージ後、以下の現象が現れました
- 開発環境・本番環境ともに、検証ツールのコンソールに以下の警告が表示される  
  [![Image from Gyazo](https://i.gyazo.com/b05b3fd8058066e7bf9071c204eff830.png)](https://gyazo.com/b05b3fd8058066e7bf9071c204eff830)
  ```bash
  Chrome is moving towards a new experience that allows users to choose to browse without third-party cookies.
  # Chromeは、ユーザーが第三者クッキーを使わずにブラウジングすることを選択できる新しい体験に向かっています
  ``` 
**修正後**
- 開発環境は、検証ツールのコンソールに警告が表示されなくなった
  [![Image from Gyazo](https://i.gyazo.com/140b2008cd9a1a26b97b404c7bfde9be.png)](https://gyazo.com/140b2008cd9a1a26b97b404c7bfde9be)
- 本番環境では、まだ警告が出ます（参考資料：[`Chrome is moving towards a new experience…`ってなに？](https://graphtone-note.co.jp/note/note-4710/)）
  [![Image from Gyazo](https://i.gyazo.com/462b3a57cd9e40d835be1cf243677535.png)](https://gyazo.com/462b3a57cd9e40d835be1cf243677535)
___
**修正内容**
- `app/controllers/openai_posts_controller.rb`に以下を追加
  - `secure:`：本番環境で動いているときだけクッキーはHTTPSを使って配送され、クッキーが盗まれるリスクを減らす
  - `httponly:`：JavaScriptからそのクッキーにアクセスできなくり、XSS攻撃でクッキーが盗まれにくくなる
  - `samesite:`：CSRF対策（最終的に追加）
    ```rb
    class OpenaiPostsController < ApplicationController
        protect_from_forgery  # CSRF対策
        def answer
            ...
            Time.zone = "Tokyo"
            cookies[:cookie_count] = { value: Time.zone.today.to_s, expires: Time.zone.now + 1.day,
    +                                   secure: Rails.env.production?,  httponly: true, same_site: :lax }
        end
    end
    ```
____
# 結論
- 開発環境では警告が消えましたが、本番環境では消えません。
  参考資料：[`Chrome is moving towards a new experience…`ってなに？](https://graphtone-note.co.jp/note/note-4710/)にあるように
  現時点でこの警告を消したり・対応する処理はないものと捉えました。
  「Googleがまた3rd Party Cookieに関する方針を変える可能性もある」とのことで、今後の様子みかと思います。
___
# アドバイスが欲しいこと
- 上記の認識で正しかったでしょうか？
- また、プライバシーポリシーにて`Cookieに関しての取り扱い`を追記しましたが  
   別途で（例えばAI生成時に）ユーザー向けに「今cookieを取得しました」とメッセージなどを表示させるべきでしょうか？
  [![Image from Gyazo](https://i.gyazo.com/966140df6e2a6211af26fdd408fd564f.png)](https://gyazo.com/966140df6e2a6211af26fdd408fd564f)