### PR TITLE
fix: 遊び方・ゲームクリア後のモーダルを修正 close #307

### DIFF
--- a/app/assets/images/footer/menu/menus.svg
+++ b/app/assets/images/footer/menu/menus.svg
@@ -6,8 +6,8 @@
 	.st0{fill:#4B4B4B;}
 </style>
 <g>
-	<circle class="st0" cx="256" cy="55.091" r="55.091" style="fill: rgb(255, 141, 71);"></circle>
-	<circle class="st0" cx="256" cy="256" r="55.091" style="fill: rgb(255, 141, 71);"></circle>
-	<circle class="st0" cx="256" cy="456.909" r="55.091" style="fill: rgb(255, 141, 71);"></circle>
+	<circle class="st0" cx="256" cy="55.091" r="55.091" style="fill: rgb(255, 110, 0);"></circle>
+	<circle class="st0" cx="256" cy="256" r="55.091" style="fill: rgb(255, 110, 0);"></circle>
+	<circle class="st0" cx="256" cy="456.909" r="55.091" style="fill: rgb(255, 110, 0);"></circle>
 </g>
 </svg>

--- a/app/views/games/_clear_modal.html.erb
+++ b/app/views/games/_clear_modal.html.erb
@@ -18,14 +18,14 @@
                     <div class="mt-2 px-7 py-3">
                         <p class="text-sm text-orange-500">どう思った〜？？</p>
                     </div>
-                    <div class="twitter flex justify-center pb-6">
+                    <div class="twitter flex justify-center">
                         <% share_text = "#{@post.user.name}さんが思う<br>#{@post.title}<br>あるあるを<br>" %> <!-- 変数に代入 -->
                         <%= link_to "https://twitter.com/intent/tweet?url=#{request.base_url}/games/#{@post.id}/start&text=#{ERB::Util.url_encode("\n#{@post.user.name}さんが思う\n##{@post.title.gsub(/[^\p{Alnum}\s]/u, '')} あるあるをシェア！\n#あるある神経衰弱 \n")}",
                             target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア",
                             class: "rounded-lg p-2
                                     font-bold text-[#808080] bg-pink-50 border-2 border-pink-200 drop-shadow-md
                                     hover:text-[#FF7611] hover:bg-yellow-100 hover:border-yellow-200 hover:drop-shadow-none" do %>
-                            <span class="font-medium text-xs">
+                            <span class="font-medium text-sm">
                                 <%= share_text.html_safe %>
                             </span> <!-- ここで変数を使用 -->
                             <%= image_tag 'xshare.svg', class: "inline-flex items-center h-6 w-6", id: 'image-xshare' %>でシェアしよう！
@@ -33,6 +33,9 @@
                     </div></br>
                     <div class="pb-4">
                         <%= render "shared/xreview_button" %>
+                    </div>
+                    <div class="pt-8">
+                        <%= render "shared/login_status" %>
                     </div>
 
                 <% end %>

--- a/app/views/games/_clear_modal.html.erb
+++ b/app/views/games/_clear_modal.html.erb
@@ -1,5 +1,5 @@
 <div id="modal" class="fixed inset-0 bg-orange-300 bg-opacity-50 overflow-y-auto h-full w-full hidden">
-    <div class="relative top-40 mx-auto p-4 w-80 shadow-lg rounded-lg bg-white">
+    <div class="relative top-32 mx-auto p-4 w-80 shadow-lg rounded-lg bg-white">
         <div class="mt-3 text-center">
             <div class="flex flex-col items-center">
 
@@ -31,7 +31,7 @@
                             <%= image_tag 'xshare.svg', class: "inline-flex items-center h-6 w-6", id: 'image-xshare' %>でシェアしよう！
                         <% end %>
                     </div></br>
-                    <div class="pb-4">
+                    <div class="pb-2">
                         <%= render "shared/xreview_button" %>
                     </div>
                     <div class="pt-8">

--- a/app/views/shared/header/_menu.html.erb
+++ b/app/views/shared/header/_menu.html.erb
@@ -2,7 +2,7 @@
 
     <div tabindex="0" role="button"
         class="menus-btn bg-yellow-50 hover:bg-yellow-50 border-0 hover:border-none">
-    <%= image_tag 'footer/menu/menus.svg', width: '20', height: '20', class: 'drop-shadow-md hover:drop-shadow-none'%>
+    <%= image_tag 'footer/menu/menus.svg', width: '25', height: '25', class: 'drop-shadow-md hover:drop-shadow-none'%>
     </div>
 
     <ul tabindex="0" class="dropdown-content menu bg-white rounded-xl z-[1] w-[220px] mt-6 shadow-lg">

--- a/app/views/tops/_howto.html.erb
+++ b/app/views/tops/_howto.html.erb
@@ -3,33 +3,23 @@
     onclick="howto.showModal()">遊び方</button>
 
 <dialog id="howto" class="modal">
-    <div class="modal-box fixed transform bg-white rounded-lg max-w-[600px] p-2 z-50 drop-shadow-lg md:px-6">
-        <div class="py-2 text-[#ff5900]">
-            <h3 class="text-pink-500 font-bold text-xl text-center text-[#ff0090]">🥳　遊び方　🥳</h3>
+    <div class="modal-box fixed transform bg-white rounded-lg max-w-[600px] z-50 drop-shadow-lg">
+        <div class="text-orange-500">
+            <h3 class="text-pink-500 font-bold text-xl text-center text-pink-500">🥳　遊び方　🥳</h3>
             <div class="font-bold text-center px-2 py-4">あらゆる界隈をすこーし探求できるゲーム</div>
-            <div class="howto-text pl-2 flex flex-col items-center">
-                ①　あるあるを知りたい界隈を入力！<br>
-                ＡＩがあるあるを生成してくれるよ
-                <div class="flex">
-                    <%= image_tag 'howto/AI-search.png', width: '50', height: '10' %>
-                    <%= image_tag 'howto/AI-lines.jpeg', width: '230', height: '10' %>
-                </div>
+            <div class="howto-text flex flex-col items-center">
+                好きな界隈のあるあるを投稿しよう！
+                <img src="https://i.gyazo.com/a0d84ef0d742d69be28e5d5d7552ff89.gif" alt="Image from Gyazo" width="220"/></a>
                 <br>
 
-                <div class="text-left">
-                    <div class="flex">
-                    ②　<%= image_tag 'howto/start-button.png', class: 'rounded-circle mr-2', width: '130', height: '2' %>で</div>
-                    札をめくり、あるあるを揃えよう
-                </div>
-                <%= image_tag 'howto/howto_game.png', width: '300' %>
+                みんなが作ったあるあるで遊ぼう！
+                <img src="https://i.gyazo.com/0c80c3257072ad532da1f9dcb11266aa.gif" alt="Image from Gyazo" width="220"/></a>
                 <br>
 
-                <div class="flex space-x-3">
-                    ③　<%= image_tag 'howto/howto_menus.png', width: '250' %>
-                </div>
-                誰かのあるあるで遊んだり
+                あるあるを知りたい界隈を入力すると<br>
+                ＡＩがあるあるを作ってくれるよ！
+                <img src="https://i.gyazo.com/5582e53134acd44d73224eecad2a6837.gif" alt="Image from Gyazo" width="220"/></a>
                 <br>
-                あるあるを自作してシェアしよう！
             </div>
         </div>
     </div>

--- a/app/views/tops/_howto.html.erb
+++ b/app/views/tops/_howto.html.erb
@@ -1,5 +1,6 @@
 <button class="btn font-bold text-lg drop-shadow-md hover:drop-shadow-md
-                bg-yellow-50 hover:bg-cyan-50 text-[#F50968] hover:text-[#5099ff]"
+                border-4 border-white hover:border-orange-400
+                bg-cyan-100 hover:bg-white text-pink-500 hover:text-orange-500"
     onclick="howto.showModal()">遊び方</button>
 
 <dialog id="howto" class="modal">

--- a/app/views/tops/_howto.html.erb
+++ b/app/views/tops/_howto.html.erb
@@ -3,10 +3,10 @@
     onclick="howto.showModal()">遊び方</button>
 
 <dialog id="howto" class="modal">
-    <div class="modal-box fixed transform bg-white rounded-lg max-w-[600px] z-50 drop-shadow-lg">
+    <div class="modal-box fixed transform bg-white rounded-lg max-w-[600px] max-h-[70vh] z-50 drop-shadow-lg">
         <div class="text-orange-500">
-            <h3 class="text-pink-500 font-bold text-xl text-center text-pink-500">🥳　遊び方　🥳</h3>
-            <div class="font-bold text-center px-2 py-4">あらゆる界隈をすこーし探求できるゲーム</div>
+            <h3 class="text-pink-500 font-bold text-xl text-center">🥳　遊び方　🥳</h3>
+            <div class="text-pink-500 font-bold text-center py-4">あらゆる界隈をすこーし探求するゲーム</div>
             <div class="howto-text flex flex-col items-center">
                 好きな界隈のあるあるを投稿しよう！
                 <img src="https://i.gyazo.com/a0d84ef0d742d69be28e5d5d7552ff89.gif" alt="Image from Gyazo" width="220"/></a>

--- a/app/views/tops/toppage.html.erb
+++ b/app/views/tops/toppage.html.erb
@@ -10,11 +10,11 @@
 
 <body class="text-center">
 
-    <div class="flex justify-center mt-4">
+    <div class="flex justify-center mt-2">
         <%= image_tag 'logo-bg-custom-yellow.png', class: 'w-64 h-64 aspect-[1/1]' %>
     </div>
 
-    <div class="flex justify-center mb-4">
+    <div class="flex justify-center mb-8">
         <%= render 'tops/howto' %>
     </div>
 
@@ -38,5 +38,6 @@
     <% else %>
         <%= render 'openai_form' %>
     <% end %>
+
 </body>
 </html>

--- a/app/views/tops/toppage.html.erb
+++ b/app/views/tops/toppage.html.erb
@@ -38,6 +38,5 @@
     <% else %>
         <%= render 'openai_form' %>
     <% end %>
-
 </body>
 </html>


### PR DESCRIPTION
# fix: 遊び方・ゲームクリア後のモーダルを修正
該当issue：#307
**できるようになったこと**
- https://aruaru-games.com 　（遊び方を見るボタンが目立つ、押すと遊び方が把握できる）
[![Image from Gyazo](https://i.gyazo.com/92a609bd035fb23a8f47a2b9acb1269c.jpg)](https://gyazo.com/92a609bd035fb23a8f47a2b9acb1269c)
[![Image from Gyazo](https://i.gyazo.com/1033a77bfc97d98c704b2aa38451fa21.gif)](https://gyazo.com/1033a77bfc97d98c704b2aa38451fa21)
____
**実装**
お問い合わせなどのメニュー
- `app/assets/images/footer/menu/menus.svg`：お問い合わせなどのメニュー素材の色を赤めに変更
- `app/views/shared/header/_menu.html.erb`：お問い合わせなどのメニュー素材を大きく

ゲームクリア後のモーダル
- `app/views/games/_clear_modal.html.erb`
  - モーダル自体の配置を少し上に移動
  - Xシェアボタンのテキストを大きくした
  - `shared/login_status`を呼び出し、投稿を促しました

遊び方ボタン・モーダル
- `app/views/tops/_howto.html.erb`：遊び方ボタン・モーダルを編集
- `app/views/tops/toppage.html.erb`：遊び方ボタンの下に余白を開けた

