### PR TITLE
FB・fix: 存在しないURLや投稿IDが含まれるURLに遷移した際のエラーを修正 close #328

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,13 @@ class ApplicationController < ActionController::Base
   before_action :set_search
   protect_from_forgery with: :exception
 
+  NOT_FOUND_ALERT = "存在しないURLにアクセスしたみたいだよ".freeze
+  # 存在しないURLにアクセスした際の処理、404ページに遷移するより、メッセージで済ませる
+  def handle_404
+      flash[:alert] = NOT_FOUND_ALERT
+      redirect_to posts_path
+  end
+
   private
 
   def configure_permitted_parameters

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,10 +1,15 @@
 class GamesController < ApplicationController
   def start
-    @post = Post.find(params[:id])
-    Rails.logger.info("ポストID: #{@post.id} を取得")
+    # find指示でnilだとエラーになるが、find_byでnilを返す処理になる
+    @post = Post.find_by(id: params[:id])
+    if @post.nil?
+        handle_404
+        return
+    end
 
-    # AIが生成した投稿には動的OGPをを生成しない
-    if @post && @post.user.name != "OPEN_AI_ANSWER"
+    Rails.logger.info("ポストID: #{@post.id} を取得")
+    # AIが生成した投稿には動的OGPを生成しない
+    if @post.user.name != "OPEN_AI_ANSWER"
       ogp_image_url = generate_and_save_ogp(@post)
       set_meta_tags(og: { image: ogp_image_url }, twitter: { image: ogp_image_url })
     else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,7 +29,11 @@ class PostsController < ApplicationController
     end
 
     def edit
-        @post = current_user.posts.find(params[:id])
+        @post = current_user.posts.find_by(id: params[:id])
+        if @post.nil?
+            handle_404
+            return
+        end
         @tags = @post.tags.map(&:tag_name).join(" ")
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,4 +48,7 @@ Rails.application.routes.draw do
       post :answer
     end
   end
+
+  # 404ページに遷移するより、メッセージで済ませておく。
+  match "*path", to: "application#handle_404", via: :all
 end


### PR DESCRIPTION
# FB・fix: 存在しないURLや投稿IDが含まれるURLに遷移した際のエラーを修正
該当issue：#328
「消した投稿IDが含まれるURLに、ブラウザバックやリロードをしたらエラーが出る」
というフィードバックをいただいたので修正しました
- **修正前**
  - ローカル
  [![Image from Gyazo](https://i.gyazo.com/9422adc26607db97fb9eb54f2033cc4f.png)](https://gyazo.com/9422adc26607db97fb9eb54f2033cc4f)
  - 本番環境
  [![Image from Gyazo](https://i.gyazo.com/0d54d24877cbe5ebbac163e735fb3091.png)](https://gyazo.com/0d54d24877cbe5ebbac163e735fb3091)
    ```bash
    INFO -- : [30d58610-d969-4348-95cc-6598f9a0c446] Started GET "/posts/164/edit" for 172.71.100.214 at 2025-01-24 09:25:59 +0000
    INFO -- : [30d58610-d969-4348-95cc-6598f9a0c446] Processing by PostsController#edit as HTML
    INFO -- : [30d58610-d969-4348-95cc-6598f9a0c446]   Parameters: {"id"=>"164"}
    INFO -- : [30d58610-d969-4348-95cc-6598f9a0c446] Completed 404 Not Found in 4ms (ActiveRecord: 0.9ms | Allocations: 990)
    ERROR -- :
     ActiveRecord::RecordNotFound (Couldn't find Post with 'id'=164 [WHERE "posts"."user_id" = $1]):
    ```
- **修正後**（存在しない投稿ID`100`でテストした際の動画）
  [![Image from Gyazo](https://i.gyazo.com/b91f99c84cf8121f56716ecaf4847d65.gif)](https://gyazo.com/b91f99c84cf8121f56716ecaf4847d65)
____

**実装**
- **ルーティング**
  - `config/routes.rb`：存在しないURLにアクセスした際に`application#handle_404`へルーティング
- **コントローラー**
  - `app/controllers/application_controller.rb`：`handle_404`メソッドを追加。
    - 存在しないURLにアクセスした際、投稿一覧でメッセージを表示
  - 存在しない投稿IDが渡されたら、`handle_404`メソッドを作動
  - `app/controllers/games_controller.rb`：`start`アクション
  - `app/controllers/posts_controller.rb`：`edit`アクション

**しなかったこと**
- 存在しないURLにアクセスした際に、404ページの表示。
  - 404ページが表示されると、ブラウザバックが面倒に感じるので
    投稿一覧に遷移し、メッセージを表示する処理にしました
