### PR TITLE
fix: インデントをスペース2つに修正 2

### DIFF
--- a/app/controllers/openai_posts_controller.rb
+++ b/app/controllers/openai_posts_controller.rb
@@ -1,33 +1,33 @@
 class OpenaiPostsController < ApplicationController
-    protect_from_forgery  # CSRF対策
+  protect_from_forgery  # CSRF対策
 
-    def answer
-        question = params[:question]
+  def answer
+    question = params[:question]
 
-        if question.blank?
-            flash[:alert] = "あるあるを知りたい界隈名を入力してね！"
-            redirect_to root_path
-            return
-        end
-
-        # お題がAIが以前生成したものであれば取得、なければ生成
-        post = Post.find_or_create_from_openai(question)
-
-        # データベースに保存されていればゲーム画面に遷移
-        if post&.persisted?
-            redirect_to start_game_path(post)
-        else
-            # postが存在が保存されてない場合、postが存在しない場合でメッセージを分岐
-            flash[:alert] = post ? "ごめんね！あるある思いつかない！代わりに投稿してね！" : "AI使いすぎちゃった！また今度使ってね！"
-            redirect_to root_path
-        end
-
-        # cookieに保存（日本時間で1日後に期限切れ）
-        Time.zone = "Tokyo"
-        # secure: 本番環境で動いているときだけクッキーはHTTPSを使って配送され、クッキーが盗まれるリスクを減らす
-        # httponly: JavaScriptからそのクッキーにアクセスできなくり、XSS攻撃でクッキーが盗まれにくくなる
-        # samesite: CSRF対策
-        cookies[:cookie_count] = { value: Time.zone.today.to_s, expires: Time.zone.now + 1.day,
-                                    secure: Rails.env.production?,  httponly: true, same_site: :lax }
+    if question.blank?
+      flash[:alert] = "あるあるを知りたい界隈名を入力してね！"
+      redirect_to root_path
+      return
     end
+
+    # お題がAIが以前生成したものであれば取得、なければ生成
+    post = Post.find_or_create_from_openai(question)
+
+    # データベースに保存されていればゲーム画面に遷移
+    if post&.persisted?
+      redirect_to start_game_path(post)
+    else
+      # postが存在が保存されてない場合、postが存在しない場合でメッセージを分岐
+      flash[:alert] = post ? "ごめんね！あるある思いつかない！代わりに投稿してね！" : "AI使いすぎちゃった！また今度使ってね！"
+      redirect_to root_path
+    end
+
+    # cookieに保存（日本時間で1日後に期限切れ）
+    Time.zone = "Tokyo"
+    # secure: 本番環境で動いているときだけクッキーはHTTPSを使って配送され、クッキーが盗まれるリスクを減らす
+    # httponly: JavaScriptからそのクッキーにアクセスできなくり、XSS攻撃でクッキーが盗まれにくくなる
+    # samesite: CSRF対策
+    cookies[:cookie_count] = { value: Time.zone.today.to_s, expires: Time.zone.now + 1.day,
+                                secure: Rails.env.production?,  httponly: true, same_site: :lax }
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,87 +1,87 @@
 class PostsController < ApplicationController
-    # ApplicationControllerのメソッドを使う
-    before_action :custom_authenticate_user!, only: %i[myindex new edit update create]
+  # ApplicationControllerのメソッドを使う
+  before_action :custom_authenticate_user!, only: %i[myindex new edit update create]
 
-    def index
-        @q = Post.ransack(params[:q])
-        @posts = if user_signed_in?
-                    @q.result(distinct: true).where.not(user_id: current_user.id)
-                        # AIが生成した投稿は（userテーブルと結合して検索し、投稿IDを取得してから）除外
-                        .where.not(id: Post.joins(:user).where(users: { name: "OPEN_AI_ANSWER" }).select(:id))
-                        .includes(:user).order(created_at: :desc)
-        else
-                    @q.result(distinct: true)
-                        # AIが生成した投稿は（userテーブルと結合して検索し、投稿IDを取得してから）除外
-                        .where.not(id: Post.joins(:user).where(users: { name: "OPEN_AI_ANSWER" }).select(:id))
-                        .includes(:user).order(created_at: :desc)
-        end
+  def index
+    @q = Post.ransack(params[:q])
+    @posts = if user_signed_in?
+                @q.result(distinct: true).where.not(user_id: current_user.id)
+                    # AIが生成した投稿は（userテーブルと結合して検索し、投稿IDを取得してから）除外
+                    .where.not(id: Post.joins(:user).where(users: { name: "OPEN_AI_ANSWER" }).select(:id))
+                    .includes(:user).order(created_at: :desc)
+    else
+                @q.result(distinct: true)
+                    # AIが生成した投稿は（userテーブルと結合して検索し、投稿IDを取得してから）除外
+                    .where.not(id: Post.joins(:user).where(users: { name: "OPEN_AI_ANSWER" }).select(:id))
+                    .includes(:user).order(created_at: :desc)
     end
+  end
 
-    def myindex
-        @q = current_user.posts.ransack(params[:q])
-        @posts = @q.result(distinct: true).where(user_id: current_user.id).includes(:user).order(created_at: :desc)
-        render "users/posts/index"
+  def myindex
+    @q = current_user.posts.ransack(params[:q])
+    @posts = @q.result(distinct: true).where(user_id: current_user.id).includes(:user).order(created_at: :desc)
+    render "users/posts/index"
+  end
+
+  def new
+    @post = Post.new
+    @tags = []
+  end
+
+  def edit
+    @post = current_user.posts.find_by(id: params[:id])
+    if @post.nil?
+      handle_404
+      return
     end
+    @tags = @post.tags.map(&:tag_name).join(" ")
+  end
 
-    def new
-        @post = Post.new
-        @tags = []
+  VALIDATION_MESSAGE = "全て入力してね！40文字までだよ！"
+
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save
+      @post.save_tags(params[:post][:tag])
+      flash[:notice] = "投稿したよ！遊んでもらおう！"
+      redirect_to myindex_posts_path
+    else
+      @tags = params[:post][:tag]
+      flash.now[:alert] = VALIDATION_MESSAGE
+      render :new, status: :unprocessable_entity
     end
+  end
 
-    def edit
-        @post = current_user.posts.find_by(id: params[:id])
-        if @post.nil?
-            handle_404
-            return
-        end
-        @tags = @post.tags.map(&:tag_name).join(" ")
+  def update
+    @post = current_user.posts.find(params[:id])
+    if @post.update(post_params)
+      @post.save_tags(params[:post][:tag])
+      flash[:notice] = "更新したよ！遊んでもらおう！"
+      redirect_to myindex_posts_path
+    else
+      @tags = params[:post][:tag]
+      flash.now[:alert] = VALIDATION_MESSAGE
+      render :edit, status: :unprocessable_entity
     end
+  end
 
-    VALIDATION_MESSAGE = "全て入力してね！40文字までだよ！"
-
-    def create
-        @post = current_user.posts.build(post_params)
-        if @post.save
-            @post.save_tags(params[:post][:tag])
-            flash[:notice] = "投稿したよ！遊んでもらおう！"
-            redirect_to myindex_posts_path
-        else
-            @tags = params[:post][:tag]
-            flash.now[:alert] = VALIDATION_MESSAGE
-            render :new, status: :unprocessable_entity
-        end
+  def destroy
+    ActiveRecord::Base.transaction do
+      post = current_user.posts.find(params[:id])
+      post.destroy!
+      flash[:notice] = "消したよ〜 また投稿してね！"
+      redirect_to myindex_posts_path, status: :see_other
     end
+  rescue => e
+      flash[:alert] = "消すの失敗！ もう一度試してみてね！"
+      redirect_to myindex_posts_path, status: :see_other
+  end
 
-    def update
-        @post = current_user.posts.find(params[:id])
-        if @post.update(post_params)
-            @post.save_tags(params[:post][:tag])
-            flash[:notice] = "更新したよ！遊んでもらおう！"
-            redirect_to myindex_posts_path
-        else
-            @tags = params[:post][:tag]
-            flash.now[:alert] = VALIDATION_MESSAGE
-            render :edit, status: :unprocessable_entity
-        end
-    end
+  private
 
-    def destroy
-        ActiveRecord::Base.transaction do
-            post = current_user.posts.find(params[:id])
-            post.destroy!
-            flash[:notice] = "消したよ〜 また投稿してね！"
-            redirect_to myindex_posts_path, status: :see_other
-        end
-    rescue => e
-        flash[:alert] = "消すの失敗！ もう一度試してみてね！"
-        redirect_to myindex_posts_path, status: :see_other
-    end
-
-    private
-
-    def post_params
-        params.require(:post)
-        .permit(:title, :aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five, :tag_name)
-        .merge(ogp: OgpCreator.build("#{current_user.name}さんが思う\n#{params[:post][:title]}"))
-    end
+  def post_params
+    params.require(:post)
+    .permit(:title, :aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five, :tag_name)
+    .merge(ogp: OgpCreator.build("#{current_user.name}さんが思う\n#{params[:post][:title]}"))
+  end
 end

--- a/app/controllers/search_posts_controller.rb
+++ b/app/controllers/search_posts_controller.rb
@@ -1,46 +1,46 @@
 class SearchPostsController < ApplicationController
-    def search
-        @q = Post.ransack(params[:q])
-        # AIが生成した投稿は除外
-        @posts = @q.result(distinct: true).where.not(user: User.find_by(name: "OPEN_AI_ANSWER"))
-        respond_to do |format|
-            format.js
-            format.html { render :search }
-        end
-        @tags = Tag.all
+  def search
+    @q = Post.ransack(params[:q])
+    # AIが生成した投稿は除外
+    @posts = @q.result(distinct: true).where.not(user: User.find_by(name: "OPEN_AI_ANSWER"))
+    respond_to do |format|
+      format.js
+      format.html { render :search }
     end
+    @tags = Tag.all
+  end
 
-    def autocomplete
-        # AIが生成した投稿は除外
-        @posts = search_posts(params[:q]).where.not(user: User.find_by(name: "OPEN_AI_ANSWER"))
-        respond_to do |format|
-            format.js
-            format.json { render json: @posts.pluck(:title) }
-        end
+  def autocomplete
+    # AIが生成した投稿は除外
+    @posts = search_posts(params[:q]).where.not(user: User.find_by(name: "OPEN_AI_ANSWER"))
+    respond_to do |format|
+      format.js
+      format.json { render json: @posts.pluck(:title) }
     end
+  end
 
-    private
+  private
 
-        def search_posts(query)
-        conditions = [
-            "title ILIKE ?",
-            "title ILIKE ?",
-            "title ILIKE ?",
-            "title ILIKE ?" ]
+  def search_posts(query)
+    conditions = [
+      "title ILIKE ?",
+      "title ILIKE ?",
+      "title ILIKE ?",
+      "title ILIKE ?" ]
 
-        search_queries = [
-            "%#{query}%",
-            "%#{query.tr('ぁ-ん', 'ァ-ン')}%",
-            "%#{query.tr('ァ-ン', 'ぁ-ん')}%",
-            "%#{query.tr('a-zA-Z', '')}%" ]
+    search_queries = [
+      "%#{query}%",
+      "%#{query.tr('ぁ-ん', 'ァ-ン')}%",
+      "%#{query.tr('ァ-ン', 'ぁ-ん')}%",
+      "%#{query.tr('a-zA-Z', '')}%" ]
 
-        posts = Post.where(conditions.join(" OR "), *search_queries)
-                    # AIが生成した投稿は（userテーブルと結合して検索し、投稿IDを取得してから）除外
-                    .where.not(id: Post.joins(:user).where(users: { name: "OPEN_AI_ANSWER" }).select(:id))
+    posts = Post.where(conditions.join(" OR "), *search_queries)
+            # AIが生成した投稿は（userテーブルと結合して検索し、投稿IDを取得してから）除外
+            .where.not(id: Post.joins(:user).where(users: { name: "OPEN_AI_ANSWER" }).select(:id))
 
-        if query.match?(/[a-zA-Z]/)
-            posts = posts.where("title ILIKE ?", "%#{query}%")
-        end
-        posts
+    if query.match?(/[a-zA-Z]/)
+      posts = posts.where("title ILIKE ?", "%#{query}%")
     end
+    posts
+  end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,22 +1,22 @@
 class TagsController < ApplicationController
-    def index
-        @tags = Tag.all
-    end
+  def index
+    @tags = Tag.all
+  end
 
-    def show
-        @tag = Tag.find(params[:id])
-        @posts = @tag.posts.order(created_at: :desc)
-    end
+  def show
+    @tag = Tag.find(params[:id])
+    @posts = @tag.posts.order(created_at: :desc)
+  end
 
-    def destroy
-        Tag.find(params[:id]).destroy()
-        redirect_to tags_path
-    end
+  def destroy
+    Tag.find(params[:id]).destroy()
+    redirect_to tags_path
+  end
 
-    private
+  private
 
-    def post_params
-        params.require(:post)
-        .permit(:title, :aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five)
-    end
+  def post_params
+    params.require(:post)
+    .permit(:title, :aruaru_one, :aruaru_two, :aruaru_three, :aruaru_four, :aruaru_five)
+  end
 end


### PR DESCRIPTION
# fix: インデントをスペース2つに修正 2
前回のプルリク #332 で修正しそこねていたファイルがあったので、修正しました。

**インデントを修正**
- インデントがスペース4つで設定されたRubyファイルを、スペース2つに設定し、インデントを整える
  - 修正前
  [![Image from Gyazo](https://i.gyazo.com/aaef1a671afcd1553dfae39b53c018ae.png)](https://gyazo.com/aaef1a671afcd1553dfae39b53c018ae)
  - 修正後
    [![Image from Gyazo](https://i.gyazo.com/3362008fdb7fd18b46588ff522ebf07a.png)](https://gyazo.com/3362008fdb7fd18b46588ff522ebf07a)

- `app/controllers/openai_posts_controller.rb`
- `app/controllers/posts_controller.rb`
- `app/controllers/search_posts_controller.rb`
- `app/controllers/tags_controller.rb`