### PR TITLE
FB・fix: ペアにならなかったカードの裏返る秒数を0.2秒遅くする close #339

### DIFF
--- a/app/javascript/games.js
+++ b/app/javascript/games.js
@@ -74,7 +74,7 @@ const handleNoMatch = (div) => {
     cardFirst.innerHTML = '';
     cardFirst = null;
     isLocked = false;
-  }, 700);  // 0.7秒の速度でノーペアのカードが伏せられる
+  }, 900);  // 0.9秒の速度でノーペアのカードが伏せられる
 };
 
 // カードをクリックした時の処理


### PR DESCRIPTION
# FB・fix: ペアにならなかったカードの裏返る秒数を0.2秒遅くする
該当issue：#339
**いただいたフィードバック**

> 2枚目をめくってペア出なかった時のカードの回転が早すぎて
> 2枚目にめくったカードの内容を確認できない。

これに関して、実はわざと早めていました。
サービスの趣旨として「あるあるに興味を持って知ってもらう」があり
「今のカードなんて書いてあったの？！」という気持ちに誘導するためです。
もちろんゲームとしては不親切な設計ではあるのは、承知の上での実装でしたが
カードに印字された文字数が短いと時間は遅く、長いと時間は短いと感じるものです。
塩梅が難しいですが、0.2秒遅く実装し直してみました。

https://aruaru-games.com/games/投稿ID/start
- **変更前**（設定 0.7秒）
  [![Image from Gyazo](https://i.gyazo.com/5cc5caca89bff3e3204174fb57c0c823.gif)](https://gyazo.com/5cc5caca89bff3e3204174fb57c0c823)
- **変更後**（設定 0.9秒）
  [![Image from Gyazo](https://i.gyazo.com/e542e112eec3586a55375d470eaf67a2.gif)](https://gyazo.com/e542e112eec3586a55375d470eaf67a2)
____
- `app/javascript/games.js`：ペアにならなかったカードの裏返る秒数を0.2秒遅くする


