### PR TITLE
fix: Xシェア時に投稿タイトルにスペースが含まれる場合は、スペースを削除 close #341

### DIFF
--- a/app/views/shared/_xshare_button.html.erb
+++ b/app/views/shared/_xshare_button.html.erb
@@ -1,5 +1,5 @@
 <div class="twitter">
-  <%= link_to "https://twitter.com/intent/tweet?url=#{request.base_url}/games/#{post.id}/start&text=#{ERB::Util.url_encode("\n\n\n#{post.user.name}さんが思う\n##{post.title.gsub(/[^\p{Alnum}　\s]/u, '').gsub(/([ 　]+)/, ' #')} あるあるをシェア！\n#あるある神経衰弱\n")}",
+  <%= link_to "https://twitter.com/intent/tweet?url=#{request.base_url}/games/#{post.id}/start&text=#{ERB::Util.url_encode("\n\n\n#{post.user.name}さんが思う\n##{post.title.gsub(/[^\p{Alnum}　\s]/u, '').gsub(/([ 　]+)/, '')} あるあるをシェア！\n#あるある神経衰弱\n")}",
       target: '_blank',
       data: { toggle: "tooltip", placement: "bottom" },
       title: "Xでシェア" do %>


### PR DESCRIPTION
# fix: Xシェア時に投稿タイトルにスペースが含まれる場合は、スペースを削除
該当issue：#341
以前、`fix: Xシェア時に投稿タイトルにスペースが含まれる場合はハッシュタグ化` https://github.com/pakira-56A/aruaru-game/pull/283
という修正をしましたが、今回で
`Xシェア時に投稿タイトルにスペースが含まれる場合は、スペースを削除`に変更しました。

___
- **変更前**（以前  https://github.com/pakira-56A/aruaru-game/pull/283 の変更後）  
  X上で投稿タイトルが`#BUMP #OF #CHICKEN `になっている
  [![Image from Gyazo](https://i.gyazo.com/707d69144fe59ef990de7d6a7abae1db.png)](https://gyazo.com/707d69144fe59ef990de7d6a7abae1db)

- **今回の変更後***  
  X上で投稿タイトルが`#BUMPCHICKEN `になっている
  [![Image from Gyazo](https://i.gyazo.com/89362348d458c75b72f8908467e58d7a.png)](https://gyazo.com/89362348d458c75b72f8908467e58d7a)
___

- `app/views/shared/_xshare_button.html.erb`：投稿タイトルにスペースが含まれる場合は、スペースを削除
  