### PR TITLE
FB・fix: 利用規約とプラポリのタイトルが、ブラウザ画面全体で見て中央に close #343

### DIFF
--- a/app/views/tops/policy.html.erb
+++ b/app/views/tops/policy.html.erb
@@ -1,6 +1,9 @@
+<div class="flex justify-center">
+  <h1 class="text-2xl font-bold mt-4">プライバシーポリシー</h1>
+</div>
+
 <section class="container mx-auto p-4 text-gray-600">
   <section>
-    <h2 class="text-2xl font-semibold mb-4 text-center">プライバシーポリシー</h2>
     <h3 class="text-md font-semibold mb-4">お客様から取得する情報</h3>
     <p class="mb-4">当方は、お客様から以下の情報を取得します。</p>
     <ul class="list-disc list-inside mb-4">

--- a/app/views/tops/term.html.erb
+++ b/app/views/tops/term.html.erb
@@ -1,5 +1,8 @@
+<div class="flex justify-center">
+  <h1 class="text-2xl font-bold mt-4">利用規約</h1>
+</div>
+
 <section class="container mx-auto p-4 mr-7 text-gray-600">
-  <h1 class="text-xl font-bold mb-6 text-center">利用規約</h1>
 
   <section>
     <h2 class="text-lg font-semibold mb-4">本規約について</h2>


### PR DESCRIPTION
# FB・fix: 利用規約とプラポリのタイトルが、ブラウザ画面全体で見て中央に
該当issue：#343
**いただいたフィードバック**
> パソコン（24インチのモニター）で見ると
> 利用規約とプラポリのタイトルが、ブラウザ画面全体で見て中央からずれている


https://aruaru-games.com/term （利用規約）
https://aruaru-games.com/policy （プライバシーポリシー）
- **変更前**
  利用規約とプラポリのタイトルが、ブラウザ画面全体で見て中央からズレてる
  [![Image from Gyazo](https://i.gyazo.com/cff4bf1b78a54e1a7bf83be9053045aa.png)](https://gyazo.com/cff4bf1b78a54e1a7bf83be9053045aa)

- **変更後**
  利用規約とプラポリのタイトルが、**ブラウザ画面全体で見て中央**に修正
  [![Image from Gyazo](https://i.gyazo.com/7ff489dad6f44f1dc9276a4db941d07d.gif)](https://gyazo.com/7ff489dad6f44f1dc9276a4db941d07d)

____
**実装**
- `app/views/tops/term.html.erb`：利用規約の修正
- `app/views/tops/policy.html.erb`：プライバシーポリシーの修正
