### PR TITLE
fix: ログイン後に`myindex`(自作投稿一覧)に遷移させる

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    posts_path
+    myindex_posts_path
   end
 
   def custom_authenticate_user!

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -73,4 +73,4 @@ ja:
     failure:
       unauthenticated: "Googleログインが必要だよ〜！"
     omniauth_callbacks:
-      success: "ログインできたよ！どのあるあるで遊ぶ？"
+      success: "ログインできたよ！"


### PR DESCRIPTION
# fix: ログイン後に`myindex`(自作投稿一覧)に遷移させる
**できるようになったこと**
- ログイン後に自分の投稿一覧と、ユーザー名を確認できる

| 変更前 | 変更後 |
|--------|--------|
| 他者の投稿一覧に遷移 | 自作投稿一覧に遷移 |
| <img src="https://gyazo.com/1572d2740d537ca74a415af5c118013d.gif" alt="Image from Gyazo" height="500"/> | <img src="https://gyazo.com/d59128282ecf33cc5e6eaeec60a718bc.gif" alt="Image from Gyazo" height="500"/> |
____
**実装**
- `app/controllers/application_controller.rb`：ログイン後の遷移先を変更
- `config/locales/devise.views.ja.yml`：ログイン後のメッセージを変更