### PR TITLE
fix: gameコントローラーに、動的OGP生成に特化したメソッドを用意

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,12 @@
 # 
 該当issue：#
+- https://aruaru-games.com/
 **できるようになったこと**
-- 
-  - https://aruaru-games.com/
-- 
-  - https://aruaru-games.com/
 
+| 変更前 | 変更後 |
+|--------|--------|
+|  |  |
+| <img src=".gif" alt="Image from Gyazo" height="500"/> | <img src=".gif" alt="Image from Gyazo" height="500"/> |
 ____
 **実装**
 [参考記事]()

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 !/tmp/storage/.keep
 
 /public/assets
+/public/OGP
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -19,57 +19,57 @@
 
 /* ゲーム画面 （Tailwindに書き換えられず） */
 #panel {
-    background-color: rgba(233, 252, 255, 0.995);
-    border-radius: 10px;
-    width: 400px;
-    height: 550px;
-    overflow: hidden; }
+  background-color: rgba(233, 252, 255, 0.995);
+  border-radius: 10px;
+  width: 400px;
+  height: 550px;
+  overflow: hidden; }
 
 .card {
-    width: 180px;
-    height: 98px;
-    border-radius: 10px;
+  width: 180px;
+  height: 98px;
+  border-radius: 10px;
 
-    box-shadow: rgb(255, 115, 0) 0px 4px;
-    float: left;
-    margin: 5px 0px 6px 13px;
-    cursor: pointer;
+  box-shadow: rgb(255, 115, 0) 0px 4px;
+  float: left;
+  margin: 5px 0px 6px 13px;
+  cursor: pointer;
 
-    color: rgb(244, 0, 175);
-    text-align: center;
-    justify-content: center;
-    text-wrap: balance;
-    font-size: 15px;
-    font-weight: bold;
-    background: rgb(255, 255, 247);
+  color: rgb(244, 0, 175);
+  text-align: center;
+  justify-content: center;
+  text-wrap: balance;
+  font-size: 15px;
+  font-weight: bold;
+  background: rgb(255, 255, 247);
 
-    transform-style: preserve-3d; /* 3D効果を維持 */
-    -webkit-transform: rotateY(0.5turn);  /* 横に回転(古いブラウザ用) */
-    transform: rotateY(0.5turn);  /* 横に回転 */
-    -webkit-transition: transform 0.5s;  /* 回転する速度(古いブラウザ用) */
-    transition: transform 0.5s; } /* 回転する速度 */
+  transform-style: preserve-3d; /* 3D効果を維持 */
+  -webkit-transform: rotateY(0.5turn);  /* 横に回転(古いブラウザ用) */
+  transform: rotateY(0.5turn);  /* 横に回転 */
+  -webkit-transition: transform 0.5s;  /* 回転する速度(古いブラウザ用) */
+  transition: transform 0.5s; } /* 回転する速度 */
 
 /* カードが裏の状態 */
 .back {
-    background-size: 180px 98px;
-    background-image: url('game-cardback.png'); }
+  background-size: 180px 98px;
+  background-image: url('game-cardback.png'); }
 
 .back:hover {
-    box-shadow: none;
-    border: 2px solid rgb(255, 132, 0, 0.827); }
+  box-shadow: none;
+  border: 2px solid rgb(255, 132, 0, 0.827); }
 
 /* カードが表の状態 */
 .card:not(.back) { transform: rotateY(0); } /* 反転させない */
 
 /* ペアになったカード */
 .finish {
-    background-color: white;
-    box-shadow: none;
-    border: 2px solid rgb(255, 132, 0, 0.827); }
+  background-color: white;
+  box-shadow: none;
+  border: 2px solid rgb(255, 132, 0, 0.827); }
 
 
 
 /* ローディングアニメーション */
 .loaded {
-    opacity: 0;
-    display: none; }
+  opacity: 0;
+  display: none; }

--- a/app/assets/stylesheets/custom_alerts.css
+++ b/app/assets/stylesheets/custom_alerts.css
@@ -1,21 +1,21 @@
 /* Omniauthのフラッシュメッセージ */
 .custom-alert {
-    padding: 15px;
-    background-color: #f44336;
-    color: white;
-    margin-bottom: 20px;
-    border-radius: 5px;
-    font-size: 16px;}
+  padding: 15px;
+  background-color: #f44336;
+  color: white;
+  margin-bottom: 20px;
+  border-radius: 5px;
+  font-size: 16px;}
 
 .custom-alert .close {
-    margin-left: 15px;
-    color: white;
-    font-weight: bold;
-    float: right;
-    font-size: 22px;
-    line-height: 20px;
-    cursor: pointer;
-    transition: 0.3s;}
+  margin-left: 15px;
+  color: white;
+  font-weight: bold;
+  float: right;
+  font-size: 22px;
+  line-height: 20px;
+  cursor: pointer;
+  transition: 0.3s;}
 
 .custom-alert .close:hover {
-    color: black;}
+  color: black;}

--- a/app/controllers/concerns/ogp_creator.rb
+++ b/app/controllers/concerns/ogp_creator.rb
@@ -16,6 +16,7 @@ class OgpCreator
     text_b = text_b.gsub("'", "’").force_encoding("UTF-8")
     image = MiniMagick::Image.open(BASE_IMAGE_PATH)
 
+    # 緑色はユーザー名、青色は投稿名を表記します
     image.combine_options do |config|
       config.font FONT
       config.fill "green"

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,35 +1,33 @@
 class GamesController < ApplicationController
   def start
     @post = Post.find_by(id: params[:id])
-    if @post.nil?
-        handle_404
-        return
-    end
+    # 投稿がないなら、404メッセージを表示
+    return handle_404 if @post.nil?
 
     Rails.logger.info("ポストID: #{@post.id} を取得")
-    if @post.user.name != "OPEN_AI_ANSWER"
-      ogp_image_url = generate_and_save_ogp(@post)
-      set_meta_tags(og: { image: ogp_image_url }, twitter: { image: ogp_image_url })
-    else
-      Rails.logger.info("OGPを生成しない: AIが生成した投稿です")
-    end
+    # AIが生成した投稿でなければ、動的OGPを生成
+    generate_ogp if @post.user.name != "OPEN_AI_ANSWER"
   end
 
   private
 
-  def generate_and_save_ogp(post)
-    begin
-      image_data = OgpCreator.build("#{post.user.name}さんが思う\n#{post.title}")
-      # Rails.logger.info("生成した動的OGP画像URL: #{post.ogp.url}")
-
-      post.update!(ogp: image_data)
-      # 動的OGPに不具合があった時用に、loggerを残してます
-      Rails.logger.info("生成した動的OGP画像を保存: #{post.ogp.url}")
-      post.ogp.url
-
-    rescue StandardError => e
-      Rails.logger.error("動的OGP画像の生成 または保存に失敗: #{e.message}")
-      nil
+  def generate_ogp
+    ogp_image_url = generate_and_save_ogp(@post)
+    if ogp_image_url
+      set_meta_tags(og: { image: ogp_image_url }, twitter: { image: ogp_image_url })
+    else
+      Rails.logger.info("OGP生成に失敗した")
     end
+  end
+
+  def generate_and_save_ogp(post)
+    image_data = OgpCreator.build("#{post.user.name}さんが思う\n#{post.title}")
+    post.update!(ogp: image_data)
+    # 動的OGPに不具合があった時用に、loggerを残してます
+    Rails.logger.info("生成した動的OGP画像を保存: #{post.ogp.url}")
+    post.ogp.url
+  rescue StandardError => e
+    Rails.logger.error("動的OGP画像の生成 または保存に失敗: #{e.message}")
+    nil
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,35 +17,45 @@ class Post < ApplicationRecord
   end
 
   def save_tags(tags)
+    # .uniqで同じタグ名が複数あれば削除
     tag_list = tags.split(/[[:blank:]]+|、|。|,|\./).uniq
     current_tags = self.tags.pluck(:tag_name)
     old_tags = current_tags - tag_list
     new_tags = tag_list - current_tags
 
+    # tagsテーブルから、old_tagsを探し出して削除
     old_tags.each do |old|
       self.tags.delete Tag.find_by(tag_name: old)
     end
 
+    # tagsテーブルからnew_tagsを探し、tag_mapsテーブルにtag_idを追加
     new_tags.each do |new|
+      # tag_nameがnewと一致するタグを探し、1件もなければ作成
       new_post_tag = Tag.find_or_create_by(tag_name: new)
+      # new_post_tagには、見つけたor作成したタグが格納
       self.tags << new_post_tag
     end
   end
 
-  # AIに生成させる場合（お題の文字数制限は、入力フォームで制限してます）
+  # AIに生成させる場合、過去に作ってればそれを、なければ新たに作成（お題の文字数制限は、入力フォームで制限してます）
   def self.find_or_create_from_openai(question)
+    # Railsののキャッシュから、AIが作成したお題の投稿がないか探す
     cached_post = Rails.cache.fetch("openai_post_#{question}") do
       find_by(title: question, user: User.find_by(name: "OPEN_AI_ANSWER"))
     end
 
+    # キャッシュに、AIが作成したお題の投稿が見つかった場合、その投稿を返す
     return cached_post if cached_post
 
+    # OpenAIサービスを呼び出して、questionに対する応答を取得
     openai_response = OpenaiService.get_response(question)
+    # もし取得できなかったら、nilを返す
     return nil unless openai_response
 
     answers = process_openai_response(openai_response)
     post = create_from_answers(question, answers)
 
+    # 作成した投稿がデータベースに保存されたら（post.persisted?がtrueなら）、再度キャッシュにその投稿を保存
     Rails.cache.write("openai_post_#{question}", post) if post.persisted?
     post
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
-  has_one_attached :avatar
-  attr_accessor :remove_avatar
-
   validates :uid, presence: true, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
   has_many :posts, dependent: :destroy

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -26,7 +26,8 @@
                                 'アニメのオープニング『富・名声・力』のくだり聴きいっちゃう',
                                 '丸い植え込み見ると、ガイモンさんが恋しい',
                                 'ギンに振る舞われたの、チャーハンと間違えがち'][index]}",
-            data: { character_counter_target: "input" }, maxlength: 40 %>
+            data: { character_counter_target: "input" },
+            maxlength: 40 %>
         <p class="absolute right-2 bottom-2 text-xs text-green-500">
           あと <strong data-character-counter-target="counter"></strong> 字まで
         </p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,14 +1,14 @@
 <div class="flex flex-col items-center">
-    <div class="flex items-center mb-2">
-        <div class="text-3xl font-bold text-green-600">みんなが思う</div>
-        <div class="text-lg font-bold text-lime-500 ml-2"><%= "界隈あるある一覧" %></div>
+  <div class="flex items-center mb-2">
+    <div class="text-3xl font-bold text-green-600">みんなが思う</div>
+    <div class="text-lg font-bold text-lime-500 ml-2"><%= "界隈あるある一覧" %></div>
+  </div>
+  <div class="text-md text-cyan-500 pb-2 text-center"><%= "ゆかりがない界隈でも遊んでみよう！" %>
+    <div class="pt-2 pb-4">
+      <%= render "shared/xreview_button" %>
     </div>
-    <div class="text-md text-cyan-500 pb-2 text-center"><%= "ゆかりがない界隈でも遊んでみよう！" %>
-        <div class="pt-2 pb-4">
-            <%= render "shared/xreview_button" %>
-        </div>
-    </div>
+  </div>
 
-    <%= render 'shared/posts/existence_or_empty', post: @posts %>
+  <%= render 'shared/posts/existence_or_empty', post: @posts %>
 
 </div>


### PR DESCRIPTION
# fix: gameコントローラーに、動的OGP生成に特化したメソッドを用意

**できるようになったこと**
- ユーザーにとっては変化なし
**目的**
読みやすいコードにリファクタリング
____
**実装**
- `app/controllers/games_controller.rb`
  - 既存の`generate_and_save_ogp`メソッドは、動的OGPの生成も保存も両方していました
  - 今回は`generate_ogp`(動的OGP生成に特化したメソッド)を追加し、`generate_and_save_ogp`の一部の生成処理をになってもらいました。  
    `start`アクションに投稿データが渡り、AIが生成した投稿出ない場合に使うメソッドになります。
  - `generate_ogp`メソッドでは、動的OGPを生成を生成する際は  
    `ogp_image_url`に`generate_and_save_ogp(@post)`を代入した上で  
    `set_meta_tags`を使い、静的OGPデータに、動的OGP用のデータを上書きします

**しなかったこと**
- 動的OGPを生成した事がある投稿には、以前作った動的OGP画像を再利用する。
  - 試みましたが、既存の動的OGP画像がある投稿の場合  
    投稿名が更新された場合は、動的OGP画像が新たに生成され・更新ができましたが  
    ユーザー名のみが更新された場合は、動的OGP画像がどうしても新たに生成できなかったです。
  - ユーザーAさんが投稿し、ユーザー名を変更した後に投稿をXシェアすると  
    変更前のユーザー名で動的OGP画像が生成されてしまうので、断念しました。
____
以下のファイルの変更はCSS調整やインデント修正など、今回の実装とは無関係の内容。
- インデント修正
  - `app/assets/stylesheets/application.tailwind.css`
  - `app/assets/stylesheets/custom_alerts.css`
  - `app/views/posts/_form.html.erb`
  - `app/views/posts/index.html.erb`
- コメントを追記
  - `app/controllers/concerns/ogp_creator.rb`
  - `app/controllers/concerns/ogp_creator.rb`
- `.gitignore`：`/public/OGP`をリモートにpushさせない
- `.github/PULL_REQUEST_TEMPLATE.md`：プルリクテンプレ修正
____
