### PR TITLE
`.rspec`にフォーマットドキュメンテーションを追記

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation


### PR DESCRIPTION
# `.rspec`にフォーマットドキュメンテーションを追記
**できるようになったこと**
- Rspec実行時、実行したテストケースが表示される
  [![Image from Gyazo](https://i.gyazo.com/87bfde0695a4638114c0c1c2db2a6077.jpg)](https://gyazo.com/87bfde0695a4638114c0c1c2db2a6077)
____
**実装**
- `.rspec`
  ```diff
    --require spec_helper
  + --format documentation
  ```
