### PR TITLE
fix: ページ名を`トップページ`からサイト名に変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,6 @@
 <html lang="ja">
   <head>
-    <title><%= content_for(:title) || "あるある神経衰弱" %></title>
+    <title><%= content_for(:title) || "あるある神経衰弱：界隈探求ゲーム" %></title>
       <meta name="viewport" content="width=device-width,initial-scale=1">
       <meta name="mobile-web-app-capable" content="yes">
       <%= csrf_meta_tags %>

--- a/app/views/tops/toppage.html.erb
+++ b/app/views/tops/toppage.html.erb
@@ -1,8 +1,4 @@
-<% content_for :title do %>
-  トップページ
-<% end %>
-
-  <script src="https://accounts.google.com/gsi/client" async defer></script>
+<script src="https://accounts.google.com/gsi/client" async defer></script>
 
 <body class="text-center">
 
@@ -36,4 +32,3 @@
     <%= render 'openai_form' %>
   <% end %>
 </body>
-


### PR DESCRIPTION
# fix: ページ名を`トップページ`からサイト名に変更
- https://aruaru-games.com/

| 変更前 | 変更後 |
|--------|--------|
|  |  |
| <img src="https://gyazo.com/66af6ffb1d92fcbfd8d3577ba71ffb2e.png" alt="Image from Gyazo"  width="290" /> | <img src="https://gyazo.com/03bf0cd0b6bd2e7cba6feb6522ada20f.png" alt="Image from Gyazo"  width="290" /> |
____
**実装**
- **ビュー**
  - `app/views/layouts/application.html.erb`：タブに表示するサイト名を修正
  - `app/views/tops/toppage.html.erb`：`content_for :title do`を削除
