### PR TITLE
fix:ヘッダーのメニュー、ドロップダウンの向きを変更

### DIFF
--- a/app/views/shared/header/_menu.html.erb
+++ b/app/views/shared/header/_menu.html.erb
@@ -1,4 +1,4 @@
-<div class="dropdown">
+<div class="dropdown dropdown-end">
 
   <div tabindex="0" role="button">
     <%= image_tag 'footer/menus.svg', width: '25', height: '25', class: 'drop-shadow-md hover:drop-shadow-none'%>


### PR DESCRIPTION
# fix:ヘッダーのメニュー、ドロップダウンの向きを変更
- https://aruaru-games.com/

**できるようになったこと**
- ヘッダーのメニュー、ドロップダウンの中身が見れる

| 変更前 | 変更後 |
|--------|--------|
|  |  |
| <img src="https://gyazo.com/6ec329583f920e311f039cd9adf96a9d.png" alt="Image from Gyazo" width="500"/> | <img src="https://gyazo.com/441742bbd0f69f0ae4ef2d4a5808f866.png" alt="Image from Gyazo" width="500"/> |
____
**実装**
[使ったDasyUI - **Dropdown / aligns to end of button horizontally**](https://daisyui.com/components/dropdown/#dropdown--aligns-to-end-of-button-horizontally)
- `app/views/shared/header/_menu.html.erb`：fix:ヘッダーのメニュー、ドロップダウンの向きを変更
