### PR TITLE
fix: AI生成のゲーム画面では、ブラウザバックボタンを表示させない

### DIFF
--- a/app/views/games/start.html.erb
+++ b/app/views/games/start.html.erb
@@ -50,7 +50,9 @@
             data-aruaru-five="<%= @post.aruaru_five %>">
     </div>
 
-    <%= render "shared/browser_back_button" %>
+    <% if @post.user.name != "OPEN_AI_ANSWER" %>
+        <%= render "shared/browser_back_button" %>
+    <% end %>
 
   </div>
 </div>


### PR DESCRIPTION
# fix: AI生成のゲーム画面では、ブラウザバックボタンを表示させない
- https://aruaru-games.com/

**できるようになったこと**
- AI生成のゲーム画面では、ブラウザバックボタンを表示させない

| 変更前 | 変更後 |
|--------|--------|
|  |  |
| <img src="https://i.gyazo.com/9872bc73ce419f9f6b917230a206c79e.png" alt="Image from Gyazo" width="250"/> | <img src="https://i.gyazo.com/03cc08db62d21f383dcf00d570551ce8.png" alt="Image from Gyazo" width="250"/> |
____
**実装**
- `app/views/games/start.html.erb`：条件分岐で、ブラウザバックボタンを表示/非表示にした